### PR TITLE
Support parsing JSON messages up to a maximum depth

### DIFF
--- a/parser/json/options.go
+++ b/parser/json/options.go
@@ -1,7 +1,10 @@
 package json
 
+import "math"
+
 const (
-	defaultMaxDepth = 3
+	// By default the full JSON message is parsed.
+	defaultMaxDepth = math.MaxInt64
 )
 
 // Options provide a set of parsing options.


### PR DESCRIPTION
cc @notbdu 

This PR adds logic to support parsing JSON messages up to a configurable maximum depth. The depth limitation currently only applies to JSON objects in the input message. If an object contains nested key/values that are below the maximum depth, the parser simply skips over any value for fast processing, and return an empty object instead. The benchmark shows that for complex objects, parsing with a smaller maximum depth (1 in the benchmarks) can result in a parsing speedup of **2x - 10x.**

For example, for input JSON string below:
```
{
	"foo": 123,
	"bar": [
		{
			"baz": {
				"cat": 456,
				"car": 789
			},
			"dar": ["bbb"]
		},
		666
	],
	"rad": ["usa"],
	"pat": {
		"qat": {
			"xw": {
				"woei": "oiwers",
				"234": "sdflk"
			},
			"bw": 123
		},
		"tab": {
			"enter": "return"
		},
		"bzr": 123
	}
}
```
A parser with a maximum depth of 1 will parse it as
```
{
       "foo": 123,
       "bar": [
           {}, 
           666
       ],
       "rad": ["usa"],
       "pat":{}
}
```
and a parser with a maximum depth of 2 will parse it as
```
{
       "foo": 123,
       "bar": [
             {
                 "baz": {},
                 "dar": ["bbb"]
             },
            666
       ],
       "rad": ["usa"],
       "pat": {
            "qat": {},
            "tab": {},
            "bzr": 123
       }
}
```