### PR TITLE
Add field definition and field iterator interface/implementation

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -1,0 +1,13 @@
+package event
+
+import (
+	"github.com/xichen2020/eventdb/event/field"
+)
+
+// Event is a discrete, timestamped event.
+type Event struct {
+	ID        []byte
+	TimeNanos int64
+	Fields    field.Iterator
+	RawData   []byte
+}

--- a/event/field/field.go
+++ b/event/field/field.go
@@ -1,0 +1,43 @@
+package field
+
+// ValueType is the type of a field value.
+type ValueType int
+
+// List of supported field value types.
+const (
+	Unknown ValueType = iota
+	NullType
+	BoolType
+	IntegerType
+	DoubleType
+	StringType
+)
+
+// Value is a value union.
+type Value struct {
+	Type      ValueType
+	BoolVal   bool
+	IntVal    int
+	DoubleVal float64
+	StringVal string
+}
+
+// Field is an event field.
+type Field struct {
+	Path  []string
+	Value Value
+}
+
+// Iterator iterate over a set of fields
+type Iterator interface {
+	// Next returns true if there are more fields to be iterated over,
+	// and false otherwise.
+	Next() bool
+
+	// Current returns the current field. The field remains valid
+	// until the next Next() call.
+	Current() Field
+
+	// Close closes the iterator.
+	Close()
+}

--- a/value/iterator.go
+++ b/value/iterator.go
@@ -1,0 +1,90 @@
+package value
+
+import (
+	"github.com/xichen2020/eventdb/event/field"
+	"github.com/xichen2020/eventdb/x/convert"
+)
+
+// jsonIterator iterates over fields in a JSON value.
+type jsonIterator struct {
+	objs  []objectIndex
+	path  []string
+	value field.Value
+}
+
+// NewFieldIterator creates a new field iterator from a JSON value.
+// NB(xichen): This iterator currently skips all nested JSON arrays.
+func NewFieldIterator(v *Value) field.Iterator {
+	var (
+		objs []objectIndex
+		path = make([]string, 0, 4)
+	)
+	if v.Type() == ObjectType {
+		obj := v.MustObject()
+		objs = append(objs, objectIndex{obj: obj, idx: -1})
+		path = append(path, "")
+	}
+	return &jsonIterator{
+		objs: objs,
+		path: path,
+	}
+}
+
+func (it *jsonIterator) Next() bool {
+	for len(it.objs) > 0 {
+		lastIdx := len(it.objs) - 1
+		for it.objs[lastIdx].idx++; it.objs[lastIdx].idx < it.objs[lastIdx].obj.Len(); it.objs[lastIdx].idx++ {
+			kv := it.objs[lastIdx].obj.At(it.objs[lastIdx].idx)
+			v := kv.Value()
+			switch v.Type() {
+			case NullType:
+				it.path[lastIdx] = kv.Key()
+				it.value.Type = field.NullType
+				return true
+			case BoolType:
+				it.path[lastIdx] = kv.Key()
+				it.value.Type = field.BoolType
+				it.value.BoolVal = v.MustBool()
+				return true
+			case StringType:
+				it.path[lastIdx] = kv.Key()
+				it.value.Type = field.StringType
+				it.value.StringVal = v.MustString()
+				return true
+			case NumberType:
+				it.path[lastIdx] = kv.Key()
+				n := kv.Value().MustNumber()
+				if iv, ok := convert.TryAsInt(n); ok {
+					it.value.Type = field.IntegerType
+					it.value.IntVal = iv
+				} else {
+					it.value.Type = field.DoubleType
+					it.value.DoubleVal = n
+				}
+				return true
+			case ObjectType:
+				it.path[lastIdx] = kv.Key()
+				it.path = append(it.path, "")
+				it.objs = append(it.objs, objectIndex{obj: v.MustObject(), idx: -1})
+				return it.Next()
+			default:
+				// NB: Skip arrays.
+				continue
+			}
+		}
+		it.objs = it.objs[:lastIdx]
+		it.path = it.path[:len(it.path)-1]
+	}
+	return false
+}
+
+func (it *jsonIterator) Current() field.Field {
+	return field.Field{Path: it.path, Value: it.value}
+}
+
+func (it *jsonIterator) Close() {}
+
+type objectIndex struct {
+	obj Object
+	idx int
+}

--- a/value/iterator_test.go
+++ b/value/iterator_test.go
@@ -1,0 +1,101 @@
+package value
+
+import (
+	"testing"
+
+	"github.com/xichen2020/eventdb/event/field"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFieldIterator(t *testing.T) {
+	v := NewObjectValue(
+		NewObject(NewKVArray([]KV{
+			{k: "xx", v: NewNumberValue(33.33, nil)},
+			{k: "foo", v: NewArrayValue(NewArray([]*Value{
+				NewNumberValue(123, nil),
+				NewStringValue("bar", nil),
+			}, nil), nil)},
+			{k: "blah", v: NewObjectValue(NewObject(NewKVArray([]KV{
+				{k: "bar", v: NewArrayValue(NewArray([]*Value{
+					NewStringValue("baz", nil),
+				}, nil), nil)},
+				{k: "x", v: NewStringValue("y", nil)},
+				{k: "duh", v: NewBoolValue(true, nil)},
+				{k: "par", v: NewObjectValue(NewObject(NewKVArray([]KV{
+					{k: "meh", v: NewNumberValue(3.0, nil)},
+					{k: "got", v: NewNumberValue(4.5, nil)},
+					{k: "are", v: NewNullValue(nil)},
+				}, nil)), nil)},
+			}, nil)), nil)},
+			{k: "", v: NewStringValue("empty-key", nil)},
+			{k: "empty-value", v: NewStringValue("", nil)},
+		}, nil)), nil)
+
+	expected := []field.Field{
+		{
+			Path:  []string{"xx"},
+			Value: field.Value{Type: field.DoubleType, DoubleVal: 33.33},
+		},
+		{
+			Path:  []string{"blah", "x"},
+			Value: field.Value{Type: field.StringType, StringVal: "y"},
+		},
+		{
+			Path:  []string{"blah", "duh"},
+			Value: field.Value{Type: field.BoolType, BoolVal: true},
+		},
+		{
+			Path:  []string{"blah", "par", "meh"},
+			Value: field.Value{Type: field.IntegerType, IntVal: 3},
+		},
+		{
+			Path:  []string{"blah", "par", "got"},
+			Value: field.Value{Type: field.DoubleType, DoubleVal: 4.5},
+		},
+		{
+			Path:  []string{"blah", "par", "are"},
+			Value: field.Value{Type: field.NullType},
+		},
+		{
+			Path:  []string{""},
+			Value: field.Value{Type: field.StringType, StringVal: "empty-key"},
+		},
+		{
+			Path:  []string{"empty-value"},
+			Value: field.Value{Type: field.StringType, StringVal: ""},
+		},
+	}
+
+	it := NewFieldIterator(v)
+	defer it.Close()
+
+	i := 0
+	for it.Next() {
+		f := it.Current()
+		compareTestField(t, expected[i], f)
+		i++
+	}
+	require.Equal(t, len(expected), i)
+}
+
+// Since field value is a union, the actual value may have irrelevant parts of
+// the value set, which means we can't simply use `Equal` to compare the two values.
+func compareTestField(t *testing.T, expected, actual field.Field) {
+	require.Equal(t, expected.Path, actual.Path)
+	require.Equal(t, expected.Value.Type, actual.Value.Type)
+	switch expected.Value.Type {
+	case field.NullType:
+		return
+	case field.BoolType:
+		require.Equal(t, expected.Value.BoolVal, actual.Value.BoolVal)
+	case field.IntegerType:
+		require.Equal(t, expected.Value.IntVal, actual.Value.IntVal)
+	case field.DoubleType:
+		require.Equal(t, expected.Value.DoubleVal, actual.Value.DoubleVal)
+	case field.StringType:
+		require.Equal(t, expected.Value.StringVal, actual.Value.StringVal)
+	default:
+		require.Fail(t, "unexpected value type %v", expected.Value.Type)
+	}
+}

--- a/value/object.go
+++ b/value/object.go
@@ -32,6 +32,9 @@ func (o *Object) MarshalTo(dst []byte) ([]byte, error) {
 // Len returns the number of items in the object.
 func (o *Object) Len() int { return len(o.kvs.raw) }
 
+// At returns the key value pair at given index.
+func (o *Object) At(i int) KV { return o.kvs.raw[i] }
+
 // Get returns the value for the given key in the o, and a bool indicating
 // whether the value is found.
 func (o *Object) Get(key string) (*Value, bool) {
@@ -68,6 +71,12 @@ type KV struct {
 func NewKV(k string, v *Value) KV {
 	return KV{k: k, v: v}
 }
+
+// Key returns the key.
+func (kv KV) Key() string { return kv.k }
+
+// Value returns the value.
+func (kv KV) Value() *Value { return kv.v }
 
 // KVArray is an array of key value pairs.
 type KVArray struct {

--- a/x/convert/numeric.go
+++ b/x/convert/numeric.go
@@ -1,0 +1,12 @@
+package convert
+
+// TryAsInt try to convert a floating point number to
+// an integer, returning the integral value and true
+// if the given number is indeed an integer, and false otherwise.
+func TryAsInt(v float64) (int, bool) {
+	i := int(v)
+	if v == float64(i) {
+		return i, true
+	}
+	return 0, false
+}


### PR DESCRIPTION
cc @notbdu 

This PR adds the `Field` struct and the `Iterator` interface for iterating over fields. It also adds an iterator implementation based on a JSON value.