### PR TITLE
Initial in-memory segment implementation

### DIFF
--- a/.excludecoverage
+++ b/.excludecoverage
@@ -1,4 +1,5 @@
 _mock.go
+generic_.*.go
 generated/
 vendor/
 integration/

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ clean:
 	@rm -f *.html *.xml *.out *.test
 
 .PHONY: all
-all: metalint test-ci-unit test-ci-integration eventdb
+all: metalint test-ci-unit test-ci-integration services tools
 	@echo Made all successfully
 
 .DEFAULT_GOAL := all

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ LINUX_AMD64_ENV := GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 SERVICES := \
 	eventdb
 
+TOOLS := \
+	benchdb
+
 .PHONY: setup
 setup:
 	mkdir -p $(BUILD)
@@ -55,6 +58,28 @@ services-linux-amd64:
 	$(LINUX_AMD64_ENV) make services
 
 $(foreach SERVICE,$(SERVICES),$(eval $(SERVICE_RULES)))
+
+define TOOL_RULES
+
+.PHONY: $(TOOL)
+$(TOOL): setup
+	@echo Building $(TOOL)
+	$(VENDOR_ENV) go build -o $(BUILD)/$(TOOL) ./tools/$(TOOL)/.
+
+.PHONY: $(TOOL)-linux-amd64
+$(TOOL)-linux-amd64:
+	$(LINUX_AMD64_ENV) make $(TOOL)
+
+endef
+
+.PHONY: tools
+tools: $(TOOLS)
+
+.PHONY: tools-linux-amd64
+tools-linux-amd64:
+	$(LINUX_AMD64_ENV) make tools
+
+$(foreach TOOL,$(TOOLS),$(eval $(TOOL_RULES)))
 
 .PHONY: metalint
 metalint: install-metalinter install-linter-badtime

--- a/event/event.go
+++ b/event/event.go
@@ -8,6 +8,6 @@ import (
 type Event struct {
 	ID        []byte
 	TimeNanos int64
-	Fields    field.Iterator
+	FieldIter field.Iterator
 	RawData   []byte
 }

--- a/event/field/field.go
+++ b/event/field/field.go
@@ -8,7 +8,7 @@ const (
 	Unknown ValueType = iota
 	NullType
 	BoolType
-	IntegerType
+	IntType
 	DoubleType
 	StringType
 )

--- a/glide.lock
+++ b/glide.lock
@@ -1,14 +1,16 @@
 hash: ab923de46b056bfd5c32dbb2dd43d4f1c35bb27b7246434bd5334420a10463aa
-updated: 2018-11-25T10:25:28.723461-05:00
+updated: 2018-11-25T22:25:51.388707-05:00
 imports:
 - name: github.com/apache/thrift
-  version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
+  version: b2a4d4ae21c789b689dd162deb819665567f481c
   subpackages:
   - lib/go/thrift
 - name: github.com/gogo/protobuf
   version: 636bf0302bc95575d69441b25a2603156ffdddf1
   subpackages:
   - proto
+- name: github.com/google/uuid
+  version: 9b3b1e0f5f99ae461456d768e7d301a7acdaa2d8
 - name: github.com/m3db/m3cluster
   version: d971450316604c151719f53afbb95539e6dbafbb
   subpackages:
@@ -31,6 +33,16 @@ imports:
   version: e937528877485c089aa62cfa9f60968749d650f1
   subpackages:
   - generic
+- name: github.com/pborman/uuid
+  version: 8b1b92947f46224e3b97bb1a3a5b0382be00d31e
+- name: github.com/pilosa/pilosa
+  version: 3673636902468d576d09e6ecb0c40d922feaef3a
+  subpackages:
+  - logger
+  - roaring
+  - stats
+- name: github.com/pkg/errors
+  version: 059132a15dd08d6704c67711dae0cf35ab991756
 - name: github.com/spaolacci/murmur3
   version: 9f5d223c60793748f04a9d5b4b4eacddfc1f755d
 - name: github.com/uber-go/tally

--- a/parser/json/options.go
+++ b/parser/json/options.go
@@ -7,11 +7,15 @@ const (
 	defaultMaxDepth = math.MaxInt64
 )
 
+// ObjectKeyFilterFn filters out values associated with keys matching the filter.
+type ObjectKeyFilterFn func(key string) bool
+
 // Options provide a set of parsing options.
 // TODO(xichen): limit the maximum capacity of each caching array via options.
 // TODO(xichen): limit the maximum capacity of cached value arrays and KV arrays via options.
 type Options struct {
-	maxDepth int
+	maxDepth          int
+	objectKeyFilterFn ObjectKeyFilterFn
 }
 
 // NewOptions creates a new set of parsing options.
@@ -30,3 +34,13 @@ func (o *Options) SetMaxDepth(v int) *Options {
 
 // MaxDepth returns the maximum depth eligible for parsing.
 func (o *Options) MaxDepth() int { return o.maxDepth }
+
+// SetObjectKeyFilterFn sets the object key matching function.
+func (o *Options) SetObjectKeyFilterFn(v ObjectKeyFilterFn) *Options {
+	opts := *o
+	opts.objectKeyFilterFn = v
+	return &opts
+}
+
+// ObjectKeyFilterFn returns the object key matching function.
+func (o *Options) ObjectKeyFilterFn() ObjectKeyFilterFn { return o.objectKeyFilterFn }

--- a/parser/json/parser_test.go
+++ b/parser/json/parser_test.go
@@ -184,6 +184,45 @@ func TestParserParseIncompleteObject(t *testing.T) {
 	}
 }
 
+func TestParseObjectKeyFilterFn(t *testing.T) {
+	input := `
+	{
+		"foo": 123,
+		"bar": [
+			{
+				"baz": {
+					"cat": 456,
+					"car": 789
+				},
+				"dar": ["bbb"]
+			},
+			666
+		],
+		"rad": ["usa"],
+		"pat": {
+			"qat": {
+				"xw": {
+					"woei": "oiwers",
+					"234": "sdflk"
+				},
+				"bw": 123
+			},
+			"tab": {
+				"enter": "return"
+			},
+			"bzr": 123
+		}
+	}
+`
+	filterFn := func(key string) bool { return key == "cat" || key == "qat" }
+	expected := `{"foo":123,"bar":[{"baz":{"car":789},"dar":["bbb"]},666],"rad":["usa"],"pat":{"tab":{"enter":"return"},"bzr":123}}`
+	opts := NewOptions().SetObjectKeyFilterFn(filterFn)
+	p := NewParser(opts)
+	v, err := p.Parse(input)
+	require.NoError(t, err)
+	require.Equal(t, expected, testMarshalled(t, v))
+}
+
 func TestParserSkipObjectValue(t *testing.T) {
 	inputs := []struct {
 		str string

--- a/server/http/handlers/service.go
+++ b/server/http/handlers/service.go
@@ -115,7 +115,7 @@ func (s *service) Write(w http.ResponseWriter, r *http.Request) {
 	ev := event.Event{
 		ID:        id,
 		TimeNanos: timeNanos,
-		Fields:    fieldIter,
+		FieldIter: fieldIter,
 		RawData:   data,
 	}
 

--- a/storage/database.go
+++ b/storage/database.go
@@ -62,6 +62,9 @@ func NewDatabase(
 	shardSet sharding.ShardSet,
 	opts *Options,
 ) Database {
+	if opts == nil {
+		opts = NewOptions()
+	}
 	nss := make(map[hash.Hash]databaseNamespace, len(namespaces))
 	for _, ns := range namespaces {
 		h := hash.BytesHash(ns)

--- a/storage/field.go
+++ b/storage/field.go
@@ -1,0 +1,163 @@
+package storage
+
+import (
+	"github.com/xichen2020/eventdb/event/field"
+
+	"github.com/pilosa/pilosa/roaring"
+)
+
+const (
+	defaultFieldValuesCapacity = 64
+)
+
+// fieldWriter writes the value for a given field.
+// NB: The docIDs passed in to field writer must be always monotonically increasing.
+// TODO(xichen): Investigate the overhead of using roaring bitmap for sparse fields.
+// TODO(xichen): Investigate more compact encoding of the values for memory efficiency.
+// TODO(xichen): Perhaps pool the type-specific writers and the roaring bitmaps.
+type fieldWriter struct {
+	path []string
+	nw   *nullValueWriter
+	bw   *boolValueWriter
+	iw   *intValueWriter
+	dw   *doubleValueWriter
+	sw   *stringValueWriter
+}
+
+func newFieldWriter(path []string) *fieldWriter {
+	return &fieldWriter{
+		path: path,
+	}
+}
+
+func (w *fieldWriter) addValue(docID int32, v field.Value) {
+	switch v.Type {
+	case field.NullType:
+		w.addNull(docID)
+	case field.BoolType:
+		w.addBool(docID, v.BoolVal)
+	case field.IntType:
+		w.addInt(docID, v.IntVal)
+	case field.DoubleType:
+		w.addDouble(docID, v.DoubleVal)
+	case field.StringType:
+		w.addString(docID, v.StringVal)
+	}
+}
+
+func (w *fieldWriter) addNull(docID int32) {
+	if w.nw == nil {
+		w.nw = newNullValueWriter()
+	}
+	w.nw.add(docID)
+}
+
+func (w *fieldWriter) addBool(docID int32, val bool) {
+	if w.bw == nil {
+		w.bw = newBoolValueWriter()
+	}
+	w.bw.add(docID, val)
+}
+
+func (w *fieldWriter) addInt(docID int32, val int) {
+	if w.iw == nil {
+		w.iw = newIntValueWriter()
+	}
+	w.iw.add(docID, val)
+}
+
+func (w *fieldWriter) addDouble(docID int32, val float64) {
+	if w.dw == nil {
+		w.dw = newDoubleValueWriter()
+	}
+	w.dw.add(docID, val)
+}
+
+func (w *fieldWriter) addString(docID int32, val string) {
+	if w.sw == nil {
+		w.sw = newStringValueWriter()
+	}
+	w.sw.add(docID, val)
+}
+
+type nullValueWriter struct {
+	docIDs *roaring.Bitmap
+}
+
+func newNullValueWriter() *nullValueWriter {
+	return &nullValueWriter{
+		docIDs: roaring.NewBitmap(),
+	}
+}
+
+func (nw *nullValueWriter) add(docID int32) {
+	nw.docIDs.Add(uint64(docID))
+}
+
+type boolValueWriter struct {
+	docIDs *roaring.Bitmap
+	vals   []bool
+}
+
+func newBoolValueWriter() *boolValueWriter {
+	return &boolValueWriter{
+		docIDs: roaring.NewBitmap(),
+		vals:   make([]bool, 0, defaultFieldValuesCapacity),
+	}
+}
+
+func (nw *boolValueWriter) add(docID int32, val bool) {
+	nw.docIDs.Add(uint64(docID))
+	nw.vals = append(nw.vals, val)
+}
+
+type intValueWriter struct {
+	docIDs *roaring.Bitmap
+	vals   []int
+}
+
+func newIntValueWriter() *intValueWriter {
+	return &intValueWriter{
+		docIDs: roaring.NewBitmap(),
+		vals:   make([]int, 0, defaultFieldValuesCapacity),
+	}
+}
+
+func (nw *intValueWriter) add(docID int32, val int) {
+	nw.docIDs.Add(uint64(docID))
+	nw.vals = append(nw.vals, val)
+}
+
+type doubleValueWriter struct {
+	docIDs *roaring.Bitmap
+	vals   []float64
+}
+
+func newDoubleValueWriter() *doubleValueWriter {
+	return &doubleValueWriter{
+		docIDs: roaring.NewBitmap(),
+		vals:   make([]float64, 0, defaultFieldValuesCapacity),
+	}
+}
+
+func (nw *doubleValueWriter) add(docID int32, val float64) {
+	nw.docIDs.Add(uint64(docID))
+	nw.vals = append(nw.vals, val)
+}
+
+type stringValueWriter struct {
+	docIDs *roaring.Bitmap
+	vals   []string
+}
+
+func newStringValueWriter() *stringValueWriter {
+	return &stringValueWriter{
+		docIDs: roaring.NewBitmap(),
+		vals:   make([]string, 0, defaultFieldValuesCapacity),
+	}
+}
+
+func (nw *stringValueWriter) add(docID int32, val string) {
+	nw.docIDs.Add(uint64(docID))
+	nw.vals = append(nw.vals, val)
+}

--- a/storage/options.go
+++ b/storage/options.go
@@ -1,9 +1,31 @@
 package storage
 
+const (
+	defaultNestedFieldSeparator = '.'
+)
+
 // Options provide a set of options for the database.
-type Options struct{}
+type Options struct {
+	nestedFieldSeparator byte
+}
 
 // NewOptions create a new set of options.
 func NewOptions() *Options {
-	return &Options{}
+	return &Options{
+		nestedFieldSeparator: defaultNestedFieldSeparator,
+	}
+}
+
+// SetNestedFieldSeparator sets the path separator when flattening nested event fields.
+// This is used when persisting and querying nested fields.
+func (o *Options) SetNestedFieldSeparator(v byte) *Options {
+	opts := *o
+	opts.nestedFieldSeparator = v
+	return &opts
+}
+
+// NestedFieldSeparator returns the path separator when flattening nested event fields.
+// This is used when persisting and querying nested fields.
+func (o *Options) NestedFieldSeparator() byte {
+	return o.nestedFieldSeparator
 }

--- a/storage/segment.go
+++ b/storage/segment.go
@@ -1,10 +1,22 @@
 package storage
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
 	"github.com/xichen2020/eventdb/event"
+	"github.com/xichen2020/eventdb/x/hash"
+)
+
+const (
+	defaultInitialNumDocs   = 4096
+	defaultInitialNumFields = 64
+)
+
+var (
+	// errSegmentAlreadySealed is raised when trying to mutabe a sealed segment.
+	errSegmentAlreadySealed = errors.New("segment is already sealed")
 )
 
 // mutableDatabaseSegment is an immutable database segment.
@@ -29,18 +41,57 @@ type dbSegment struct {
 	sync.RWMutex
 
 	opts *Options
+
+	// NB: We refer to an event containing a collection of fields a document
+	// in conventional information retrieval terminology.
+	sealed       bool
+	numDocs      int32
+	minTimeNanos int64
+	maxTimeNanos int64
+	fields       map[hash.Hash]*fieldWriter
+	rawDocs      [][]byte
 }
 
 func newMutableDatabaseSegment(
 	opts *Options,
 ) *dbSegment {
 	return &dbSegment{
-		opts: opts,
+		opts:    opts,
+		numDocs: 0,
+		rawDocs: make([][]byte, 0, defaultInitialNumDocs),
+		fields:  make(map[hash.Hash]*fieldWriter, defaultInitialNumFields),
 	}
 }
 
 func (s *dbSegment) Write(ev event.Event) error {
-	return fmt.Errorf("not implemented")
+	s.Lock()
+	if s.sealed {
+		s.Unlock()
+		return errSegmentAlreadySealed
+	}
+	if s.minTimeNanos > ev.TimeNanos {
+		s.minTimeNanos = ev.TimeNanos
+	}
+	if s.maxTimeNanos < ev.TimeNanos {
+		s.maxTimeNanos = ev.TimeNanos
+	}
+	docID := s.numDocs
+	s.numDocs++
+	s.rawDocs = append(s.rawDocs, ev.RawData)
+
+	for ev.FieldIter.Next() {
+		f := ev.FieldIter.Current()
+		pathHash := hash.StringArrayHash(f.Path, s.opts.NestedFieldSeparator())
+		w, exists := s.fields[pathHash]
+		if !exists {
+			w = newFieldWriter(f.Path)
+			s.fields[pathHash] = w
+		}
+		w.addValue(docID, f.Value)
+	}
+	ev.FieldIter.Close()
+	s.Unlock()
+	return nil
 }
 
 func (s *dbSegment) Seal() immutableDatabaseSegment {

--- a/tools/benchdb/main.go
+++ b/tools/benchdb/main.go
@@ -1,0 +1,145 @@
+// This tool is used to benchmark the performance impact of different database designs.
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/xichen2020/eventdb/event"
+	"github.com/xichen2020/eventdb/parser/json"
+	"github.com/xichen2020/eventdb/sharding"
+	"github.com/xichen2020/eventdb/storage"
+	"github.com/xichen2020/eventdb/value"
+	"github.com/xichen2020/eventdb/x/unsafe"
+
+	"github.com/m3db/m3cluster/shard"
+	"github.com/m3db/m3x/log"
+	"github.com/pborman/uuid"
+)
+
+var (
+	inputFile  = flag.String("inputFile", "", "input file containing sample events")
+	numShards  = flag.Int("numShards", 8, "number of shards")
+	numWorkers = flag.Int("numWorkers", 1, "number of workers processing events in parallel")
+
+	logger         = log.SimpleLogger
+	eventNamespace = []byte("testNamespace")
+)
+
+func main() {
+	flag.Parse()
+
+	if len(*inputFile) == 0 {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	events, totalBytes, err := readEvents(*inputFile)
+	if err != nil {
+		logger.Fatalf("error reading events from input file %s: %v", *inputFile, err)
+	}
+	logger.Infof("read %d events from %d bytes", len(events), totalBytes)
+
+	db, err := createDatabase()
+	if err != nil {
+		logger.Fatalf("error creating database: %v", err)
+	}
+	if err := db.Open(); err != nil {
+		logger.Fatalf("error opening database: %v", err)
+	}
+	defer db.Close()
+
+	var (
+		wg    sync.WaitGroup
+		idx   int32 = -1
+		start       = time.Now()
+	)
+	for i := 0; i < *numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			processEvents(db, events, &idx)
+		}()
+	}
+	wg.Wait()
+
+	var (
+		dur          = time.Since(start)
+		durInSeconds = float64(dur.Nanoseconds()) / 1e9
+	)
+	logger.Infof("processed %d events in %v, throughput = %f events / s", len(events), dur, float64(len(events))/durInSeconds)
+	logger.Infof("processed %d bytes in %v, throughput = %f bytes / s", totalBytes, dur, float64(totalBytes)/durInSeconds)
+}
+
+func readEvents(fname string) ([]event.Event, int, error) {
+	f, err := os.Open(fname)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer f.Close()
+
+	var (
+		scanner    = bufio.NewScanner(f)
+		events     []event.Event
+		totalBytes int
+		parseTime  time.Duration
+	)
+	for scanner.Scan() {
+		eventStr := scanner.Text()
+		totalBytes += len(eventStr)
+		parseStart := time.Now()
+		p := json.NewParser(nil)
+		v, err := p.Parse(eventStr)
+		parseTime += time.Since(parseStart)
+		if err != nil {
+			return nil, 0, fmt.Errorf("error parsing %s: %v", eventStr, err)
+		}
+		ev := event.Event{
+			ID:        []byte(uuid.NewUUID().String()),
+			TimeNanos: time.Now().UnixNano(),
+			FieldIter: value.NewFieldIterator(v),
+			RawData:   unsafe.ToBytes(eventStr),
+		}
+		events = append(events, ev)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, 0, fmt.Errorf("error scanning %s: %v", fname, err)
+	}
+	logger.Infof("parsing %d events in %v, throughput = %f events / s", len(events), parseTime, float64(len(events))/float64(parseTime)*1e9)
+	logger.Infof("parsing %d bytes in %v, throughput = %f bytes / s", totalBytes, parseTime, float64(totalBytes)/float64(parseTime)*1e9)
+	return events, totalBytes, nil
+}
+
+func createDatabase() (storage.Database, error) {
+	namespaces := [][]byte{eventNamespace}
+	shardIDs := make([]uint32, 0, *numShards)
+	for i := 0; i < *numShards; i++ {
+		shardIDs = append(shardIDs, uint32(i))
+	}
+	shards := sharding.NewShards(shardIDs, shard.Available)
+	hashFn := sharding.DefaultHashFn(*numShards)
+	shardSet, err := sharding.NewShardSet(shards, hashFn)
+	if err != nil {
+		return nil, fmt.Errorf("error creating shard set: %v", err)
+	}
+	return storage.NewDatabase(namespaces, shardSet, nil), nil
+}
+
+func processEvents(db storage.Database, events []event.Event, currIdx *int32) {
+	for {
+		newIdx := int(atomic.AddInt32(currIdx, 1))
+		if newIdx >= len(events) {
+			return
+		}
+		ev := events[newIdx]
+		if err := db.Write(eventNamespace, ev); err != nil {
+			logger.Errorf("error writing event %s: %v", ev.RawData, err)
+		}
+	}
+}

--- a/value/iterator.go
+++ b/value/iterator.go
@@ -55,7 +55,7 @@ func (it *jsonIterator) Next() bool {
 				it.path[lastIdx] = kv.Key()
 				n := kv.Value().MustNumber()
 				if iv, ok := convert.TryAsInt(n); ok {
-					it.value.Type = field.IntegerType
+					it.value.Type = field.IntType
 					it.value.IntVal = iv
 				} else {
 					it.value.Type = field.DoubleType

--- a/value/iterator_test.go
+++ b/value/iterator_test.go
@@ -47,7 +47,7 @@ func TestFieldIterator(t *testing.T) {
 		},
 		{
 			Path:  []string{"blah", "par", "meh"},
-			Value: field.Value{Type: field.IntegerType, IntVal: 3},
+			Value: field.Value{Type: field.IntType, IntVal: 3},
 		},
 		{
 			Path:  []string{"blah", "par", "got"},
@@ -89,7 +89,7 @@ func compareTestField(t *testing.T, expected, actual field.Field) {
 		return
 	case field.BoolType:
 		require.Equal(t, expected.Value.BoolVal, actual.Value.BoolVal)
-	case field.IntegerType:
+	case field.IntType:
 		require.Equal(t, expected.Value.IntVal, actual.Value.IntVal)
 	case field.DoubleType:
 		require.Equal(t, expected.Value.DoubleVal, actual.Value.DoubleVal)


### PR DESCRIPTION
cc @notbdu 

This PR adds an initial implementation for writing to an in-memory segment. This implementation is very unoptimized and has high lock contention overhead in that updating every event requires obtaining a write lock due to adding values to each field of the event, however this should help us set a baseline for evaluation and further optimizations.

I also added a tool `benchdb` to evaluate the raw performance of parsing and processing events based on our production data.