### PR TITLE
Segment sealing and flushing (part 1)

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,9 @@
 hash: ab923de46b056bfd5c32dbb2dd43d4f1c35bb27b7246434bd5334420a10463aa
+<<<<<<< HEAD
 updated: 2018-11-27T00:38:24.267456-05:00
+=======
+updated: 2018-11-27T14:05:24.378439-05:00
+>>>>>>> Glide update
 imports:
 - name: github.com/apache/thrift
   version: b2a4d4ae21c789b689dd162deb819665567f481c
@@ -27,6 +31,7 @@ imports:
 - name: github.com/m3db/m3x
   version: 29bc232d9ad2e6c4a1804ccce095bb730fb1c6bc
   subpackages:
+  - clock
   - errors
   - instrument
   - log

--- a/glide.lock
+++ b/glide.lock
@@ -1,30 +1,22 @@
 hash: ab923de46b056bfd5c32dbb2dd43d4f1c35bb27b7246434bd5334420a10463aa
-<<<<<<< HEAD
-updated: 2018-11-27T00:38:24.267456-05:00
-=======
-updated: 2018-11-27T14:05:24.378439-05:00
->>>>>>> Glide update
+updated: 2018-11-27T14:32:40.138382-05:00
 imports:
 - name: github.com/apache/thrift
   version: b2a4d4ae21c789b689dd162deb819665567f481c
   subpackages:
   - lib/go/thrift
-- name: github.com/axiomhq/hyperloglog
-  version: e8c19f1749152250b378d1d2e92fdea63b9fa6a9
-- name: github.com/dgryski/go-metro
-  version: 280f6062b5bc97ee9b9afe7f2ccb361e59845baa
 - name: github.com/gogo/protobuf
-  version: 07eab6a8298cf32fac45cceaac59424f98421bbc
+  version: 636bf0302bc95575d69441b25a2603156ffdddf1
   subpackages:
   - proto
 - name: github.com/golang/mock
-  version: 49a60242bb5c086a9aacc67bdd056e88f75f3c3e
+  version: c34cdb4725f4c3844d095133c6e40e448b86589b
   subpackages:
   - gomock
 - name: github.com/google/uuid
   version: 9b3b1e0f5f99ae461456d768e7d301a7acdaa2d8
 - name: github.com/m3db/m3cluster
-  version: 3b9dd4710f0995c0571cbf79d38b8d8c875c4b44
+  version: d971450316604c151719f53afbb95539e6dbafbb
   subpackages:
   - generated/proto/placementpb
   - shard
@@ -70,7 +62,7 @@ imports:
 - name: go.uber.org/multierr
   version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
 - name: go.uber.org/zap
-  version: 67bc79d13d155c02fd008f721863ff8cc5f30659
+  version: ff33455a0e382e8a81d14dd7c922020b6b5e7982
   subpackages:
   - buffer
   - internal/bufferpool
@@ -78,7 +70,7 @@ imports:
   - internal/exit
   - zapcore
 - name: golang.org/x/net
-  version: adae6a3d119ae4890b46832a2e88a95adc62b8e7
+  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
   subpackages:
   - context
 testImports:
@@ -87,7 +79,7 @@ testImports:
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/stretchr/testify

--- a/persist/manager.go
+++ b/persist/manager.go
@@ -1,0 +1,34 @@
+package persist
+
+// Manager manages the internals of persisting data onto storage layer.
+type Manager interface {
+	// StartPersist starts persisting data.
+	StartPersist() (Persister, error)
+}
+
+// Persister is responsible for actually persisting data.
+type Persister interface {
+	// Prepare prepares for data persistence.
+	Prepare(opts PrepareOptions) (PreparedPersister, error)
+
+	// Done marks the persistence as complete.
+	Done() error
+}
+
+// PrepareOptions provide a set of options for data persistence.
+// TODO(xichen): Flesh this out.
+type PrepareOptions struct {
+}
+
+// Fn is a function that persists an in-memory segment.
+// TODO(xichen): Flesh this out.
+type Fn func() error
+
+// Closer is a function that performs cleanup after persistence.
+type Closer func() error
+
+// PreparedPersister is an object that wraps a persist function and a closer.
+type PreparedPersister struct {
+	Persist Fn
+	Close   Closer
+}

--- a/storage/flush.go
+++ b/storage/flush.go
@@ -1,0 +1,49 @@
+package storage
+
+import (
+	"sync"
+	"time"
+
+	"github.com/xichen2020/eventdb/persist"
+
+	"github.com/m3db/m3x/clock"
+)
+
+type databaseFlushManager interface {
+	// ComputeFlushTargets computes the list of namespaces eligible for flushing.
+	ComputeFlushTargets(namespaces []databaseNamespace) []databaseNamespace
+
+	// Flush attempts to flush the database if deemed necessary.
+	Flush(namespace databaseNamespace) error
+}
+
+type flushManager struct {
+	sync.Mutex
+
+	database database
+	pm       persist.Manager
+	opts     *Options
+
+	nowFn   clock.NowFn
+	sleepFn sleepFn
+}
+
+func newFlushManager(database database, opts *Options) *flushManager {
+	return &flushManager{
+		database: database,
+		// pm: fs.NewPersistManager()
+		opts:    opts,
+		nowFn:   opts.ClockOptions().NowFn(),
+		sleepFn: time.Sleep,
+	}
+}
+
+// NB: This is just a no-op implementation for now.
+// In reality, this should be determined based on memory usage of each namespace.
+func (mgr *flushManager) ComputeFlushTargets(namespaces []databaseNamespace) []databaseNamespace {
+	return namespaces
+}
+
+func (mgr *flushManager) Flush(namespace databaseNamespace) error {
+	return namespace.Flush(mgr.pm)
+}

--- a/storage/fs.go
+++ b/storage/fs.go
@@ -1,0 +1,101 @@
+package storage
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/m3db/m3x/clock"
+	xerrors "github.com/m3db/m3x/errors"
+	"github.com/uber-go/tally"
+)
+
+type databaseFileSystemManager interface {
+	// Run attempts to flush the database if deemed necessary.
+	Run() error
+}
+
+var (
+	errEmptyNamespaces = errors.New("empty namespaces")
+	errRunInProgress   = errors.New("another run is in progress")
+)
+
+type runStatus int
+
+// nolint:deadcode,megacheck,varcheck
+const (
+	runNotStarted runStatus = iota
+	runInProgress
+)
+
+type fileSystemManagerMetrics struct {
+	runDuration tally.Timer
+}
+
+func newFileSystemManagerMetrics(scope tally.Scope) fileSystemManagerMetrics {
+	return fileSystemManagerMetrics{
+		runDuration: scope.Timer("duration"),
+	}
+}
+
+type fileSystemManager struct {
+	sync.Mutex
+	databaseFlushManager
+
+	database database
+	opts     *Options
+
+	status  runStatus
+	metrics fileSystemManagerMetrics
+	nowFn   clock.NowFn
+	sleepFn sleepFn
+}
+
+func newFileSystemManager(database database, opts *Options) *fileSystemManager {
+	scope := opts.InstrumentOptions().MetricsScope().SubScope("fs")
+
+	return &fileSystemManager{
+		database:             database,
+		databaseFlushManager: newFlushManager(database, opts),
+		opts:                 opts,
+		nowFn:                opts.ClockOptions().NowFn(),
+		sleepFn:              time.Sleep,
+		metrics:              newFileSystemManagerMetrics(scope),
+	}
+}
+
+func (mgr *fileSystemManager) Run() error {
+	mgr.Lock()
+	defer mgr.Unlock()
+
+	if mgr.status == runInProgress {
+		return errRunInProgress
+	}
+
+	namespaces, err := mgr.database.GetOwnedNamespaces()
+	if err != nil {
+		return err
+	}
+	if len(namespaces) == 0 {
+		return errEmptyNamespaces
+	}
+
+	// Determine which namespaces are in scope for flushing.
+	toFlush := mgr.ComputeFlushTargets(namespaces)
+	if len(toFlush) == 0 {
+		// Nothing to do.
+		return nil
+	}
+
+	var (
+		start    = mgr.nowFn()
+		multiErr xerrors.MultiError
+	)
+	for _, n := range namespaces {
+		multiErr = multiErr.Add(mgr.Flush(n))
+	}
+
+	took := mgr.nowFn().Sub(start)
+	mgr.metrics.runDuration.Record(took)
+	return multiErr.FinalError()
+}

--- a/storage/mediator.go
+++ b/storage/mediator.go
@@ -1,0 +1,121 @@
+package storage
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/m3db/m3x/clock"
+)
+
+// databaseMediator mediates actions among various database managers.
+type databaseMediator interface {
+	// Open opens the mediator.
+	Open() error
+
+	// Close closes the mediator.
+	Close() error
+}
+
+type mediatorState int
+
+const (
+	runCheckInterval = 5 * time.Second
+	minRunInterval   = time.Minute
+
+	mediatorNotOpen mediatorState = iota
+	mediatorOpen
+	mediatorClosed
+)
+
+var (
+	errMediatorAlreadyOpen   = errors.New("mediator is already open")
+	errMediatorNotOpen       = errors.New("mediator is not open")
+	errMediatorAlreadyClosed = errors.New("mediator is already closed")
+)
+
+type sleepFn func(time.Duration)
+
+type mediator struct {
+	sync.RWMutex
+
+	database Database
+	databaseFileSystemManager
+
+	opts     *Options
+	nowFn    clock.NowFn
+	sleepFn  sleepFn
+	state    mediatorState
+	closedCh chan struct{}
+}
+
+func newMediator(database database, opts *Options) databaseMediator {
+	return &mediator{
+		database:                  database,
+		databaseFileSystemManager: newFileSystemManager(database, opts),
+		opts:     opts,
+		nowFn:    opts.ClockOptions().NowFn(),
+		sleepFn:  time.Sleep,
+		state:    mediatorNotOpen,
+		closedCh: make(chan struct{}),
+	}
+}
+
+func (m *mediator) Open() error {
+	m.Lock()
+	defer m.Unlock()
+	if m.state != mediatorNotOpen {
+		return errMediatorAlreadyOpen
+	}
+	m.state = mediatorOpen
+	go m.runLoop()
+	return nil
+}
+
+func (m *mediator) Close() error {
+	m.Lock()
+	defer m.Unlock()
+
+	if m.state == mediatorNotOpen {
+		return errMediatorNotOpen
+	}
+	if m.state == mediatorClosed {
+		return errMediatorAlreadyClosed
+	}
+	m.state = mediatorClosed
+	close(m.closedCh)
+	return nil
+}
+
+func (m *mediator) runLoop() {
+	for {
+		select {
+		case <-m.closedCh:
+			return
+		default:
+			m.runOnce()
+		}
+	}
+}
+
+func (m *mediator) runOnce() {
+	start := m.nowFn()
+	if err := m.databaseFileSystemManager.Run(); err == errRunInProgress {
+		// NB(xichen): if we attempt to run while another run
+		// is in progress, throttle a little to avoid constantly
+		// checking whether the ongoing run is finished.
+		m.sleepFn(runCheckInterval)
+	} else if err != nil {
+		// On critical error, we retry immediately.
+		log := m.opts.InstrumentOptions().Logger()
+		log.Errorf("error within ongoingTick: %v", err)
+	} else {
+		// Otherwise, we make sure the subsequent run is at least
+		// minRunInterval apart from the last one.
+		took := m.nowFn().Sub(start)
+		if took > minRunInterval {
+			return
+		}
+		m.sleepFn(minRunInterval - took)
+	}
+}

--- a/storage/namespace.go
+++ b/storage/namespace.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/xichen2020/eventdb/event"
+	"github.com/xichen2020/eventdb/persist"
 	"github.com/xichen2020/eventdb/sharding"
 
 	xerrors "github.com/m3db/m3x/errors"
@@ -15,6 +16,9 @@ import (
 type databaseNamespace interface {
 	// Write writes an event within the namespace.
 	Write(ev event.Event) error
+
+	// Flush performs a flush against the namespace.
+	Flush(pm persist.Manager) error
 
 	// Close closes the namespace.
 	Close() error
@@ -44,9 +48,10 @@ func newDatabaseNamespace(
 	copy(idClone, id)
 
 	n := &dbNamespace{
-		id:       id,
-		shardSet: shardSet,
-		opts:     opts,
+		id:          id,
+		shardSet:    shardSet,
+		opts:        opts,
+		tickWorkers: tickWorkers,
 	}
 	n.initShards()
 	return n
@@ -58,6 +63,10 @@ func (n *dbNamespace) Write(ev event.Event) error {
 		return err
 	}
 	return shard.Write(ev)
+}
+
+func (n *dbNamespace) Flush(pm persist.Manager) error {
+	return fmt.Errorf("not implemented")
 }
 
 func (n *dbNamespace) Close() error {
@@ -106,6 +115,18 @@ func (n *dbNamespace) shardAtWithRLock(shardID uint32) (databaseShard, error) {
 			fmt.Errorf("not responsible for shard %d", shardID))
 	}
 	return shard, nil
+}
+
+// nolint:megacheck
+func (n *dbNamespace) getOwnedShards() []databaseShard {
+	n.RLock()
+	shards := n.shardSet.AllIDs()
+	databaseShards := make([]databaseShard, len(shards))
+	for i, shard := range shards {
+		databaseShards[i] = n.shards[shard]
+	}
+	n.RUnlock()
+	return databaseShards
 }
 
 func (n *dbNamespace) closeShards(shards []databaseShard) {

--- a/storage/namespace.go
+++ b/storage/namespace.go
@@ -48,10 +48,9 @@ func newDatabaseNamespace(
 	copy(idClone, id)
 
 	n := &dbNamespace{
-		id:          id,
-		shardSet:    shardSet,
-		opts:        opts,
-		tickWorkers: tickWorkers,
+		id:       id,
+		shardSet: shardSet,
+		opts:     opts,
 	}
 	n.initShards()
 	return n

--- a/storage/options.go
+++ b/storage/options.go
@@ -1,19 +1,52 @@
 package storage
 
+import (
+	"github.com/m3db/m3x/clock"
+	"github.com/m3db/m3x/instrument"
+)
+
 const (
 	defaultNestedFieldSeparator = '.'
 )
 
 // Options provide a set of options for the database.
 type Options struct {
+	clockOpts            clock.Options
+	instrumentOpts       instrument.Options
 	nestedFieldSeparator byte
 }
 
 // NewOptions create a new set of options.
 func NewOptions() *Options {
 	return &Options{
+		clockOpts:            clock.NewOptions(),
+		instrumentOpts:       instrument.NewOptions(),
 		nestedFieldSeparator: defaultNestedFieldSeparator,
 	}
+}
+
+// SetClockOptions sets the clock options.
+func (o *Options) SetClockOptions(v clock.Options) *Options {
+	opts := *o
+	opts.clockOpts = v
+	return &opts
+}
+
+// ClockOptions returns the clock options.
+func (o *Options) ClockOptions() clock.Options {
+	return o.clockOpts
+}
+
+// SetInstrumentOptions sets the instrument options.
+func (o *Options) SetInstrumentOptions(v instrument.Options) *Options {
+	opts := *o
+	opts.instrumentOpts = v
+	return &opts
+}
+
+// InstrumentOptions returns the instrument options.
+func (o *Options) InstrumentOptions() instrument.Options {
+	return o.instrumentOpts
 }
 
 // SetNestedFieldSeparator sets the path separator when flattening nested event fields.

--- a/storage/segment.go
+++ b/storage/segment.go
@@ -20,6 +20,7 @@ var (
 )
 
 // mutableDatabaseSegment is an immutable database segment.
+// nolint:megacheck
 type immutableDatabaseSegment interface {
 }
 
@@ -30,8 +31,8 @@ type mutableDatabaseSegment interface {
 	// Write writes an event to the mutable segment.
 	Write(ev event.Event) error
 
-	// Seal seals the mutable segment and make it immutable.
-	Seal() immutableDatabaseSegment
+	// Seal seals the mutable segment and makes it immutable.
+	Seal()
 
 	// Close closes the mutable segment.
 	Close() error
@@ -94,8 +95,10 @@ func (s *dbSegment) Write(ev event.Event) error {
 	return nil
 }
 
-func (s *dbSegment) Seal() immutableDatabaseSegment {
-	panic(fmt.Errorf("not implemented"))
+func (s *dbSegment) Seal() {
+	s.Lock()
+	s.sealed = true
+	s.Unlock()
 }
 
 func (s *dbSegment) Close() error {


### PR DESCRIPTION
cc @notbdu 

This PR adds the first part of the initial logic for periodically flushing database segments to disk. This covers the `databaseMediator`, `databaseFileSystemManager`, `databaseFlushManager`, and `persist.Manager` interfaces and APIs. 