### PR TITLE
Segment flushing and persistence part 2

### DIFF
--- a/persist/persist.go
+++ b/persist/persist.go
@@ -1,5 +1,7 @@
 package persist
 
+import "github.com/pilosa/pilosa/roaring"
+
 // Manager manages the internals of persisting data onto storage layer.
 type Manager interface {
 	// StartPersist starts persisting data.
@@ -16,19 +18,29 @@ type Persister interface {
 }
 
 // PrepareOptions provide a set of options for data persistence.
-// TODO(xichen): Flesh this out.
 type PrepareOptions struct {
+	Namespace    []byte
+	Shard        uint32
+	MinTimeNanos int64
+	MaxTimeNanos int64
+	NumDocs      int
 }
 
-// Fn is a function that persists an in-memory segment.
-// TODO(xichen): Flesh this out.
-type Fn func() error
+// Fns contains a set of function that persists document IDs
+// and different types of document values for a given field.
+type Fns struct {
+	WriteNulls   func(fieldPath []string, docIDs *roaring.Bitmap) error
+	WriteBools   func(fieldPath []string, docIDs *roaring.Bitmap, vals []bool) error
+	WriteInts    func(fieldPath []string, docIDs *roaring.Bitmap, vals []int) error
+	WriteDoubles func(fieldPath []string, docIDs *roaring.Bitmap, vals []float64) error
+	WriteStrings func(fieldPath []string, docIDs *roaring.Bitmap, vals []string) error
+}
 
 // Closer is a function that performs cleanup after persistence.
 type Closer func() error
 
 // PreparedPersister is an object that wraps a persist function and a closer.
 type PreparedPersister struct {
-	Persist Fn
+	Persist Fns
 	Close   Closer
 }

--- a/storage/field.go
+++ b/storage/field.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"github.com/xichen2020/eventdb/event/field"
+	"github.com/xichen2020/eventdb/persist"
 
 	"github.com/pilosa/pilosa/roaring"
 )
@@ -78,6 +79,35 @@ func (w *fieldWriter) addString(docID int32, val string) {
 		w.sw = newStringValueWriter()
 	}
 	w.sw.add(docID, val)
+}
+
+func (w *fieldWriter) flush(persistFns persist.Fns) error {
+	if w.nw != nil {
+		if err := persistFns.WriteNulls(w.path, w.nw.docIDs); err != nil {
+			return err
+		}
+	}
+	if w.bw != nil {
+		if err := persistFns.WriteBools(w.path, w.bw.docIDs, w.bw.vals); err != nil {
+			return err
+		}
+	}
+	if w.iw != nil {
+		if err := persistFns.WriteInts(w.path, w.iw.docIDs, w.iw.vals); err != nil {
+			return err
+		}
+	}
+	if w.dw != nil {
+		if err := persistFns.WriteDoubles(w.path, w.dw.docIDs, w.dw.vals); err != nil {
+			return err
+		}
+	}
+	if w.sw != nil {
+		if err := persistFns.WriteStrings(w.path, w.sw.docIDs, w.sw.vals); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type nullValueWriter struct {

--- a/storage/options.go
+++ b/storage/options.go
@@ -3,6 +3,8 @@ package storage
 import (
 	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/instrument"
+
+	"github.com/xichen2020/eventdb/persist"
 )
 
 const (
@@ -14,6 +16,7 @@ type Options struct {
 	clockOpts            clock.Options
 	instrumentOpts       instrument.Options
 	nestedFieldSeparator byte
+	persistManager       persist.Manager
 }
 
 // NewOptions create a new set of options.
@@ -47,6 +50,18 @@ func (o *Options) SetInstrumentOptions(v instrument.Options) *Options {
 // InstrumentOptions returns the instrument options.
 func (o *Options) InstrumentOptions() instrument.Options {
 	return o.instrumentOpts
+}
+
+// SetPersistManager sets the persistence manager.
+func (o *Options) SetPersistManager(v persist.Manager) *Options {
+	opts := *o
+	opts.persistManager = v
+	return &opts
+}
+
+// PersistManager returns the persistence manager.
+func (o *Options) PersistManager() persist.Manager {
+	return o.persistManager
 }
 
 // SetNestedFieldSeparator sets the path separator when flattening nested event fields.

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -4,12 +4,20 @@ import (
 	"errors"
 	"sync"
 
+	xerrors "github.com/m3db/m3x/errors"
 	"github.com/xichen2020/eventdb/event"
+	"github.com/xichen2020/eventdb/persist"
 )
 
 type databaseShard interface {
+	// ID returns the shard ID.
+	ID() uint32
+
 	// Write writes an event within the shard.
 	Write(ev event.Event) error
+
+	// Flush flushes the segments in the shard.
+	Flush(ps persist.Persister) error
 
 	// Close closes the shard.
 	Close() error
@@ -22,25 +30,28 @@ var (
 type dbShard struct {
 	sync.RWMutex
 
-	shard uint32
-	opts  *Options
+	namespace []byte
+	shard     uint32
+	opts      *Options
 
 	closed bool
 	active mutableDatabaseSegment
-	// nolint: megacheck,structcheck
-	sealed []immutableDatabaseSegment
 }
 
 func newDatabaseShard(
+	namespace []byte,
 	shard uint32,
 	opts *Options,
 ) *dbShard {
 	return &dbShard{
-		shard:  shard,
-		opts:   opts,
-		active: newMutableDatabaseSegment(opts),
+		namespace: namespace,
+		shard:     shard,
+		opts:      opts,
+		active:    newDatabaseSegment(opts),
 	}
 }
+
+func (s *dbShard) ID() uint32 { return s.shard }
 
 func (s *dbShard) Write(ev event.Event) error {
 	s.RLock()
@@ -48,6 +59,41 @@ func (s *dbShard) Write(ev event.Event) error {
 	s.RUnlock()
 
 	return segment.Write(ev)
+}
+
+// TODO(xichen): retry logic on segment persistence failure.
+func (s *dbShard) Flush(ps persist.Persister) error {
+	var multiErr xerrors.MultiError
+	s.Lock()
+	activeSegment := s.active
+	s.active = newDatabaseSegment(s.opts)
+	s.Unlock()
+
+	activeSegment.Seal()
+	if activeSegment.NumDocs() == 0 {
+		return nil
+	}
+
+	prepareOpts := persist.PrepareOptions{
+		Namespace:    s.namespace,
+		Shard:        s.ID(),
+		MinTimeNanos: activeSegment.MinTimeNanos(),
+		MaxTimeNanos: activeSegment.MaxTimeNanos(),
+		NumDocs:      activeSegment.NumDocs(),
+	}
+	prepared, err := ps.Prepare(prepareOpts)
+	if err != nil {
+		return err
+	}
+
+	if err := activeSegment.Flush(prepared.Persist); err != nil {
+		multiErr = multiErr.Add(err)
+	}
+	if err := prepared.Close(); err != nil {
+		multiErr = multiErr.Add(err)
+	}
+
+	return multiErr.FinalError()
 }
 
 func (s *dbShard) Close() error {


### PR DESCRIPTION
cc @notbdu 

This PR is the part 2 of the segment flushing and persistence logic. Specifically, it threads the `Flush` call throughout the database ingestion path and fleshes out the persistence related data structures more in preparation for actual persistence.

NB: The type-specific persistence functions now still takes slices as the input parameter, but I can change them to be iterators later on if desired once I finish wiring up the pieces.