### PR TITLE
Write digest to segment files

### DIFF
--- a/digest/buffer.go
+++ b/digest/buffer.go
@@ -1,0 +1,55 @@
+package digest
+
+import (
+	"encoding/binary"
+	"os"
+)
+
+const (
+	// DigestLenBytes is the length of generated digests in bytes.
+	DigestLenBytes = 4
+)
+
+var (
+	// Endianness is little endian
+	endianness = binary.LittleEndian
+)
+
+// Buffer is a byte slice that facilitates digest reading and writing.
+type Buffer []byte
+
+// NewBuffer creates a new digest buffer.
+func NewBuffer() Buffer {
+	return make([]byte, DigestLenBytes)
+}
+
+// WriteDigest writes a digest to the buffer.
+func (b Buffer) WriteDigest(digest uint32) {
+	endianness.PutUint32(b, digest)
+}
+
+// WriteDigestToFile writes a digest to the file.
+func (b Buffer) WriteDigestToFile(fd *os.File, digest uint32) error {
+	b.WriteDigest(digest)
+	_, err := fd.Write(b)
+	return err
+}
+
+// ReadDigest reads the digest from the buffer.
+func (b Buffer) ReadDigest() uint32 {
+	return endianness.Uint32(b)
+}
+
+// ReadDigestFromFile reads the digest from the file.
+func (b Buffer) ReadDigestFromFile(fd *os.File) (uint32, error) {
+	_, err := fd.Read(b)
+	if err != nil {
+		return 0, err
+	}
+	return b.ReadDigest(), nil
+}
+
+// ToBuffer converts a byte slice to a digest buffer.
+func ToBuffer(buf []byte) Buffer {
+	return Buffer(buf[:DigestLenBytes])
+}

--- a/digest/buffer_test.go
+++ b/digest/buffer_test.go
@@ -1,0 +1,60 @@
+package digest
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteDigest(t *testing.T) {
+	buf := NewBuffer()
+	buf.WriteDigest(2)
+	require.Equal(t, []byte{0x2, 0x0, 0x0, 0x0}, []byte(buf))
+}
+
+func TestWriteDigestToFile(t *testing.T) {
+	fd := createTempFile(t)
+	filePath := fd.Name()
+	defer os.Remove(filePath)
+
+	buf := NewBuffer()
+	require.NoError(t, buf.WriteDigestToFile(fd, 20))
+	fd.Close()
+
+	fd, err := os.Open(filePath)
+	require.NoError(t, err)
+	b, err := ioutil.ReadAll(fd)
+	require.NoError(t, err)
+	fd.Close()
+	require.Equal(t, []byte{0x14, 0x0, 0x0, 0x0}, b)
+}
+
+func TestReadDigest(t *testing.T) {
+	buf := ToBuffer([]byte{0x0, 0x1, 0x0, 0x1, 0x0, 0x1})
+	require.Equal(t, uint32(0x1000100), buf.ReadDigest())
+}
+
+func TestReadDigestFromFile(t *testing.T) {
+	fd := createTempFile(t)
+	defer func() {
+		fd.Close()
+		os.Remove(fd.Name())
+	}()
+
+	b := []byte{0xa, 0x0, 0x0, 0x0}
+	fd.Write(b)
+	fd.Seek(0, 0)
+
+	buf := NewBuffer()
+	res, err := buf.ReadDigestFromFile(fd)
+	require.NoError(t, err)
+	require.Equal(t, uint32(10), res)
+}
+
+func createTempFile(t *testing.T) *os.File {
+	fd, err := ioutil.TempFile("", "testfile")
+	require.NoError(t, err)
+	return fd
+}

--- a/digest/digest.go
+++ b/digest/digest.go
@@ -1,0 +1,18 @@
+package digest
+
+import (
+	"hash/adler32"
+
+	"github.com/m3db/stackadler32"
+)
+
+// NewDigest creates a new digest.
+// The default 32-bit hashing algorithm is adler32.
+func NewDigest() stackadler32.Digest {
+	return stackadler32.NewDigest()
+}
+
+// Checksum returns the checksum for a buffer.
+func Checksum(buf []byte) uint32 {
+	return adler32.Checksum(buf)
+}

--- a/digest/fd_digest.go
+++ b/digest/fd_digest.go
@@ -1,0 +1,56 @@
+package digest
+
+import (
+	"hash"
+	"hash/adler32"
+	"io"
+	"os"
+)
+
+// fdWithDigest is a container for a file descriptor and the digest for the file contents.
+type fdWithDigest interface {
+	io.Closer
+
+	// Fd returns the file descriptor.
+	Fd() *os.File
+
+	// Digest returns the digest.
+	Digest() hash.Hash32
+
+	// Reset resets the file descriptor and the digest.
+	Reset(fd *os.File)
+}
+
+type fileWithDigest struct {
+	fd     *os.File
+	digest hash.Hash32
+}
+
+func newFileWithDigest() *fileWithDigest {
+	return &fileWithDigest{
+		digest: adler32.New(),
+	}
+}
+
+func (fwd *fileWithDigest) Fd() *os.File {
+	return fwd.fd
+}
+
+func (fwd *fileWithDigest) Digest() hash.Hash32 {
+	return fwd.digest
+}
+
+func (fwd *fileWithDigest) Reset(fd *os.File) {
+	fwd.fd = fd
+	fwd.digest.Reset()
+}
+
+// Close closes the file descriptor.
+func (fwd *fileWithDigest) Close() error {
+	if fwd.fd == nil {
+		return nil
+	}
+	err := fwd.fd.Close()
+	fwd.fd = nil
+	return err
+}

--- a/digest/writer.go
+++ b/digest/writer.go
@@ -1,0 +1,75 @@
+package digest
+
+import (
+	"bufio"
+	"io"
+	"os"
+)
+
+// FdWithDigestWriter provides a buffered writer for writing to the underlying file.
+type FdWithDigestWriter interface {
+	fdWithDigest
+	io.Writer
+
+	Flush() error
+}
+
+// FileWithDigestWriter writes data to a file and computes the data checksum in a
+// streaming fashion.
+type FileWithDigestWriter struct {
+	fdWithDigest
+
+	writer    *bufio.Writer
+	digestBuf Buffer
+}
+
+// NewFdWithDigestWriter creates a new FdWithDigestWriter.
+func NewFdWithDigestWriter(bufferSize int) *FileWithDigestWriter {
+	return &FileWithDigestWriter{
+		fdWithDigest: newFileWithDigest(),
+		writer:       bufio.NewWriterSize(nil, bufferSize),
+		digestBuf:    NewBuffer(),
+	}
+}
+
+// Reset resets the writer.
+func (w *FileWithDigestWriter) Reset(fd *os.File) {
+	w.fdWithDigest.Reset(fd)
+	w.writer.Reset(fd)
+}
+
+// Write bytes to the underlying file.
+func (w *FileWithDigestWriter) Write(b []byte) (int, error) {
+	written, err := w.writer.Write(b)
+	if err != nil {
+		return 0, err
+	}
+	if _, err := w.Digest().Write(b); err != nil {
+		return 0, err
+	}
+	return written, nil
+}
+
+// Close writes the final checksum to file, flushes what's remaining in
+// the buffered writer, and closes the underlying file.
+func (w *FileWithDigestWriter) Close() error {
+	if err := w.writeDigest(); err != nil {
+		return err
+	}
+	if err := w.Flush(); err != nil {
+		return err
+	}
+	return w.fdWithDigest.Close()
+}
+
+// Flush flushes what's remaining in the buffered writes.
+func (w *FileWithDigestWriter) Flush() error {
+	return w.writer.Flush()
+}
+
+func (w *FileWithDigestWriter) writeDigest() error {
+	digest := w.Digest().Sum32()
+	w.digestBuf.WriteDigest(digest)
+	_, err := w.Write(w.digestBuf)
+	return err
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: ab923de46b056bfd5c32dbb2dd43d4f1c35bb27b7246434bd5334420a10463aa
-updated: 2018-12-01T23:00:44.54275-05:00
+updated: 2018-12-02T09:09:16.163478-05:00
 imports:
 - name: github.com/apache/thrift
   version: b2a4d4ae21c789b689dd162deb819665567f481c
@@ -32,6 +32,8 @@ imports:
   - process
   - retry
   - server
+- name: github.com/m3db/stackadler32
+  version: bfebcd73ef6ffe0ee30489227f0330c39064b674
 - name: github.com/m3db/stackmurmur3
   version: 744c0229c12ed0e4f8cb9d081a2692b3300bf705
 - name: github.com/mauricelam/genny


### PR DESCRIPTION
cc @notbdu 

This PR adds logic to write data digest to segment info files and field data files. The digest is computed in a streaming fashion as data are written to the files, and appended to the end of each file.