### PR TITLE
Add benchmarks for merging multiple doc id set iters

### DIFF
--- a/document/doc_id.go
+++ b/document/doc_id.go
@@ -105,7 +105,7 @@ func newBitmapBasedDocIDSetBuilder(bm *roaring.Bitmap) *bitmapBasedDocIDSetBuild
 	return &bitmapBasedDocIDSetBuilder{bm: bm}
 }
 
-func (s *bitmapBasedDocIDSetBuilder) Add(docID int32) { s.bm.Add(uint64(docID)) }
+func (s *bitmapBasedDocIDSetBuilder) Add(docID int32) { s.bm.DirectAdd(uint64(docID)) }
 
 // NB(xichen): Clone the internal bitmap so the builder can be mutated independently
 // of the snapshot. In the future we can look into the bitmap implementation to see

--- a/document/in_all_doc_id_set_iterator.go
+++ b/document/in_all_doc_id_set_iterator.go
@@ -3,6 +3,7 @@ package document
 // inAllDocIDSetIterIterator iterates over an array of doc ID set iterators.
 // Each inner iterator outputs doc IDs in increasing order, and the outer
 // iterator only outputs a doc ID if it exists in the output of all inner iterators.
+// TODO(xichen): Look into using bitset to make this faster based on benchmark results.
 type inAllDocIDSetIterIterator struct {
 	iters []DocIDSetIterator
 

--- a/document/in_all_doc_id_set_iterator_bench_test.go
+++ b/document/in_all_doc_id_set_iterator_bench_test.go
@@ -1,0 +1,226 @@
+package document
+
+import (
+	"testing"
+
+	rroaring "github.com/RoaringBitmap/roaring"
+	proaring "github.com/pilosa/pilosa/roaring"
+	"github.com/willf/bitset"
+)
+
+func BenchmarkInAllDocIDSetIteratorDense(b *testing.B) {
+	benchmarkInAllDocIDSetIterator(b, testDenseBenchSetup)
+}
+
+func BenchmarkDocIDSetIteratorBitsetDense(b *testing.B) {
+	benchmarkDocIDSetIteratorBitset(b, testDenseBenchSetup)
+}
+
+func BenchmarkDocIDSetIteratorRRoaringBitmapDense(b *testing.B) {
+	benchmarkDocIDSetIteratorRRoaringBitmap(b, testDenseBenchSetup)
+}
+
+func BenchmarkDocIDSetIteratorPilosaRoaringBitmapDense(b *testing.B) {
+	benchmarkDocIDSetIteratorPilosaRoaringBitmap(b, testDenseBenchSetup)
+}
+
+func BenchmarkInAllDocIDSetIteratorSparse(b *testing.B) {
+	benchmarkInAllDocIDSetIterator(b, testSparseBenchSetup)
+}
+
+func BenchmarkDocIDSetIteratorBitsetSparse(b *testing.B) {
+	benchmarkDocIDSetIteratorBitset(b, testSparseBenchSetup)
+}
+
+func BenchmarkDocIDSetIteratorRRoaringBitmapSparse(b *testing.B) {
+	benchmarkDocIDSetIteratorRRoaringBitmap(b, testSparseBenchSetup)
+}
+
+func BenchmarkDocIDSetIteratorPilosaRoaringBitmapSparse(b *testing.B) {
+	benchmarkDocIDSetIteratorPilosaRoaringBitmap(b, testSparseBenchSetup)
+}
+
+func benchmarkInAllDocIDSetIterator(b *testing.B, ts testBenchSetup) {
+	bms := initBenchBitmaps(ts)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		iters := make([]DocIDSetIterator, 0, ts.numFields)
+		for _, bm := range bms {
+			iters = append(iters, newbitmapBasedDocIDIter(bm.Iterator()))
+		}
+		inAllIter := newInAllDocIDSetIterIterator(iters...)
+
+		count := 0
+		for inAllIter.Next() {
+			count++
+		}
+	}
+}
+
+func benchmarkDocIDSetIteratorBitset(b *testing.B, ts testBenchSetup) {
+	bms := initBenchBitmaps(ts)
+	iters := make([]DocIDSetIterator, 0, ts.numFields)
+	for _, bm := range bms {
+		iters = append(iters, newbitmapBasedDocIDIter(bm.Iterator()))
+	}
+
+	bs1 := bitset.New(uint(ts.totalDocs))
+	bs2 := bitset.New(uint(ts.totalDocs))
+	buf := make([]uint, 256)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bs1.ClearAll()
+		iter := bms[0].Iterator()
+		for {
+			v, eof := iter.Next()
+			if eof {
+				break
+			}
+			bs1.Set(uint(v))
+		}
+
+		for j := 1; j < ts.numFields; j++ {
+			bs2.ClearAll()
+			iter := bms[j].Iterator()
+			for {
+				v, eof := iter.Next()
+				if eof {
+					break
+				}
+				bs2.Set(uint(v))
+			}
+			bs1.InPlaceIntersection(bs2)
+		}
+
+		j := uint(0)
+		j, buf = bs1.NextSetMany(j, buf)
+		count := 0
+		for ; len(buf) > 0; j, buf = bs1.NextSetMany(j, buf) {
+			count += len(buf)
+			j++
+		}
+	}
+}
+
+func benchmarkDocIDSetIteratorRRoaringBitmap(b *testing.B, ts testBenchSetup) {
+	bms := initBenchBitmaps(ts)
+	iters := make([]DocIDSetIterator, 0, ts.numFields)
+	for _, bm := range bms {
+		iters = append(iters, newbitmapBasedDocIDIter(bm.Iterator()))
+	}
+
+	bm1 := rroaring.New()
+	bm2 := rroaring.New()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bm1.Clear()
+		iter := bms[0].Iterator()
+		for {
+			v, eof := iter.Next()
+			if eof {
+				break
+			}
+			bm1.Add(uint32(v))
+		}
+
+		for j := 1; j < ts.numFields; j++ {
+			bm2.Clear()
+			iter := bms[j].Iterator()
+			for {
+				v, eof := iter.Next()
+				if eof {
+					break
+				}
+				bm2.Add(uint32(v))
+			}
+			bm1.And(bm2)
+		}
+
+		count := 0
+		it := bm1.Iterator()
+		for it.HasNext() {
+			count++
+			it.Next()
+		}
+	}
+}
+
+func benchmarkDocIDSetIteratorPilosaRoaringBitmap(b *testing.B, ts testBenchSetup) {
+	bms := initBenchBitmaps(ts)
+	iters := make([]DocIDSetIterator, 0, ts.numFields)
+	for _, bm := range bms {
+		iters = append(iters, newbitmapBasedDocIDIter(bm.Iterator()))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bm1 := proaring.NewBitmap()
+		iter := bms[0].Iterator()
+		for {
+			v, eof := iter.Next()
+			if eof {
+				break
+			}
+			bm1.DirectAdd(uint64(v))
+		}
+
+		for j := 1; j < ts.numFields; j++ {
+			bm2 := proaring.NewBitmap()
+			iter := bms[j].Iterator()
+			for {
+				v, eof := iter.Next()
+				if eof {
+					break
+				}
+				bm2.DirectAdd(uint64(v))
+			}
+			bm1 = bm1.Intersect(bm2)
+		}
+
+		count := 0
+		it := bm1.Iterator()
+		for {
+			_, eof := it.Next()
+			if eof {
+				break
+			}
+			count++
+		}
+	}
+}
+
+func initBenchBitmaps(ts testBenchSetup) []*proaring.Bitmap {
+	bms := make([]*proaring.Bitmap, 0, ts.numFields)
+	for i := 0; i < ts.numFields; i++ {
+		bm := proaring.NewBitmap()
+		for j := 0; j < ts.totalDocs; j++ {
+			if j%ts.everyNs[i] == 0 {
+				bm.DirectAdd(uint64(j))
+			}
+		}
+		bms = append(bms, bm)
+	}
+	return bms
+}
+
+type testBenchSetup struct {
+	numFields int
+	totalDocs int
+	everyNs   []int
+}
+
+var (
+	testDenseBenchSetup = testBenchSetup{
+		numFields: 3,
+		totalDocs: 2 * 1024 * 1024,
+		everyNs:   []int{3, 6, 9},
+	}
+	testSparseBenchSetup = testBenchSetup{
+		numFields: 3,
+		totalDocs: 2 * 1024 * 1024,
+		everyNs:   []int{50, 500, 2000},
+	}
+)

--- a/document/in_all_doc_id_set_iterator_bench_test.go
+++ b/document/in_all_doc_id_set_iterator_bench_test.go
@@ -60,10 +60,6 @@ func benchmarkInAllDocIDSetIterator(b *testing.B, ts testBenchSetup) {
 
 func benchmarkDocIDSetIteratorBitset(b *testing.B, ts testBenchSetup) {
 	bms := initBenchBitmaps(ts)
-	iters := make([]DocIDSetIterator, 0, ts.numFields)
-	for _, bm := range bms {
-		iters = append(iters, newbitmapBasedDocIDIter(bm.Iterator()))
-	}
 
 	bs1 := bitset.New(uint(ts.totalDocs))
 	bs2 := bitset.New(uint(ts.totalDocs))
@@ -106,10 +102,6 @@ func benchmarkDocIDSetIteratorBitset(b *testing.B, ts testBenchSetup) {
 
 func benchmarkDocIDSetIteratorRRoaringBitmap(b *testing.B, ts testBenchSetup) {
 	bms := initBenchBitmaps(ts)
-	iters := make([]DocIDSetIterator, 0, ts.numFields)
-	for _, bm := range bms {
-		iters = append(iters, newbitmapBasedDocIDIter(bm.Iterator()))
-	}
 
 	bm1 := rroaring.New()
 	bm2 := rroaring.New()
@@ -150,10 +142,6 @@ func benchmarkDocIDSetIteratorRRoaringBitmap(b *testing.B, ts testBenchSetup) {
 
 func benchmarkDocIDSetIteratorPilosaRoaringBitmap(b *testing.B, ts testBenchSetup) {
 	bms := initBenchBitmaps(ts)
-	iters := make([]DocIDSetIterator, 0, ts.numFields)
-	for _, bm := range bms {
-		iters = append(iters, newbitmapBasedDocIDIter(bm.Iterator()))
-	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 64f605637b06cfbf7556edcada722c207a89e5ccbad266f72cd286bc480c7cfe
-updated: 2018-12-20T15:31:30.274189-05:00
+hash: b3b88f3546439e49aa3db9ffbb078e67d94ed4611f002283de326703c647712f
+updated: 2018-12-29T19:47:03.485911-05:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -106,6 +106,8 @@ imports:
   - prometheus
 - name: github.com/valyala/gozstd
   version: fce5e292979b35c0567f97a9f6d4ad4685c23b4a
+- name: github.com/willf/bitset
+  version: e553b05586428962bf7058d1044519d87ca72d74
 - name: go.uber.org/atomic
   version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
 - name: go.uber.org/multierr
@@ -132,12 +134,26 @@ testImports:
   version: d8f796af33cc11cb798c1aaeb27a4ebc5099927d
   subpackages:
   - spew
+- name: github.com/glycerine/go-unsnap-stream
+  version: f9677308dec2b35e76737f9713df328ad11b1fea
+- name: github.com/golang/snappy
+  version: 2e65f85255dbc3072edf28d6b5b8efc472979f5a
+- name: github.com/mschoch/smat
+  version: 90eadee771aeab36e8bf796039b8c261bebebe4f
+- name: github.com/philhofer/fwd
+  version: bb6d471dc95d4fe11e432687f8b70ff496cf3136
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
+- name: github.com/RoaringBitmap/roaring
+  version: 037ad138d5a9d51de1e9e74de5c1e7e296a6a862
 - name: github.com/stretchr/testify
   version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:
   - assert
   - require
+- name: github.com/tinylib/msgp
+  version: af6442a0fcf6e2a1b824f70dd0c734f01e817751
+  subpackages:
+  - msgp

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,6 +14,9 @@ import:
 - package: gopkg.in/yaml.v2
   version: ~2.2.2
 - package: github.com/dgryski/go-bitstream
+  version: 3522498ce2c8ea06df73e55df58edfbfb33cfdd6
+- package: github.com/willf/bitset
+  version: ^1.1.9
 testImport:
 - package: github.com/stretchr/testify
   version: ^1.2.2


### PR DESCRIPTION
cc @notbdu

This PR adds benchmarks to identify the most efficient approach for merging multiple doc ID set iterators. It also replaces `Add` with more efficient `DirectAdd`.