### PR TITLE
Grouped query types and initial implementation

### DIFF
--- a/document/field/field.go
+++ b/document/field/field.go
@@ -260,6 +260,26 @@ func compareTimeNanos(v1, v2 int64) int {
 	return 0
 }
 
+// ValuesLessThanFn compares two value unions and returns true if `v1` is less than `v2`.
+type ValuesLessThanFn func(v1, v2 []ValueUnion) bool
+
+// NewValuesLessThanFn creates a less than fn from a set of field value comparison functions.
+// Precondition: len(v1) == len(compareFns) && len(v2) == len(compareFn).
+func NewValuesLessThanFn(compareFns []ValueCompareFn) ValuesLessThanFn {
+	return func(v1, v2 []ValueUnion) bool {
+		for idx, fn := range compareFns {
+			res := fn(v1[idx], v2[idx])
+			if res < 0 {
+				return false
+			}
+			if res > 0 {
+				return true
+			}
+		}
+		return true
+	}
+}
+
 // Field is an event field.
 type Field struct {
 	Path  []string

--- a/document/field/field.go
+++ b/document/field/field.go
@@ -264,20 +264,52 @@ func compareTimeNanos(v1, v2 int64) int {
 type ValuesLessThanFn func(v1, v2 []ValueUnion) bool
 
 // NewValuesLessThanFn creates a less than fn from a set of field value comparison functions.
-// Precondition: len(v1) == len(compareFns) && len(v2) == len(compareFn).
+// Precondition: len(v1) == len(compareFns) && len(v2) == len(compareFns).
 func NewValuesLessThanFn(compareFns []ValueCompareFn) ValuesLessThanFn {
 	return func(v1, v2 []ValueUnion) bool {
 		for idx, fn := range compareFns {
 			res := fn(v1[idx], v2[idx])
 			if res < 0 {
-				return false
+				return true
 			}
 			if res > 0 {
-				return true
+				return false
 			}
 		}
 		return true
 	}
+}
+
+// FilterValues return a value array excluding the given value indices.
+// Precondition: Elements in `toExcludeIndices` are unique, monotonically increasing,
+// and within range [0, len(values)).
+// Postcondition: `values` is unmodified.
+func FilterValues(values []ValueUnion, toExcludeIndices []int) []ValueUnion {
+	if len(values) == 0 || len(toExcludeIndices) == 0 {
+		return values
+	}
+	if len(values) == len(toExcludeIndices) {
+		return nil
+	}
+	var (
+		valueIdx     = 0
+		toExcludeIdx = 0
+		res          = make([]ValueUnion, 0, len(values)-len(toExcludeIndices))
+	)
+
+	for valueIdx < len(values) && toExcludeIdx < len(toExcludeIndices) {
+		if valueIdx == toExcludeIndices[toExcludeIdx] {
+			toExcludeIdx++
+			valueIdx++
+			continue
+		}
+		res = append(res, values[valueIdx])
+		valueIdx++
+	}
+	if valueIdx < len(values) {
+		res = append(res, values[valueIdx:]...)
+	}
+	return res
 }
 
 // Field is an event field.

--- a/document/field/field.go
+++ b/document/field/field.go
@@ -264,6 +264,9 @@ func compareTimeNanos(v1, v2 int64) int {
 type ValuesLessThanFn func(v1, v2 []ValueUnion) bool
 
 // NewValuesLessThanFn creates a less than fn from a set of field value comparison functions.
+// The logic is such that the function returned perform a prioritized ordering of results,
+// where values at smaller indices of the array have higher priority and values at higher
+// indices are only consulted if those at smaller indices are equal.
 // Precondition: len(v1) == len(compareFns) && len(v2) == len(compareFns).
 func NewValuesLessThanFn(compareFns []ValueCompareFn) ValuesLessThanFn {
 	return func(v1, v2 []ValueUnion) bool {

--- a/document/field/field_test.go
+++ b/document/field/field_test.go
@@ -1,0 +1,75 @@
+package field
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewValuesLessThan(t *testing.T) {
+	v1 := []ValueUnion{
+		{
+			Type:      StringType,
+			StringVal: "foo",
+		},
+		{
+			Type:   IntType,
+			IntVal: 123,
+		},
+		{
+			Type:      DoubleType,
+			DoubleVal: -12.3,
+		},
+	}
+
+	v2 := []ValueUnion{
+		{
+			Type:      StringType,
+			StringVal: "foo",
+		},
+		{
+			Type:   IntType,
+			IntVal: 123,
+		},
+		{
+			Type:      DoubleType,
+			DoubleVal: -21.3,
+		},
+	}
+
+	compareFns := []ValueCompareFn{
+		MustCompareUnion,
+		MustReverseCompareUnion,
+		MustReverseCompareUnion,
+	}
+	valuesLessThanFn := NewValuesLessThanFn(compareFns)
+	require.True(t, valuesLessThanFn(v1, v2))
+}
+
+func TestFilterValues(t *testing.T) {
+	v := []ValueUnion{
+		{
+			Type:      StringType,
+			StringVal: "foo",
+		},
+		{
+			Type:   IntType,
+			IntVal: 123,
+		},
+		{
+			Type:      DoubleType,
+			DoubleVal: -12.3,
+		},
+		{
+			Type:   IntType,
+			IntVal: 456,
+		},
+		{
+			Type:      DoubleType,
+			DoubleVal: -30.2,
+		},
+	}
+	toExcludeIndices := []int{1, 4}
+	filteredValues := FilterValues(v, toExcludeIndices)
+	require.Equal(t, filteredValues, []ValueUnion{v[0], v[2], v[3]})
+}

--- a/query/calculation_op.go
+++ b/query/calculation_op.go
@@ -14,9 +14,9 @@ const (
 	Count
 	Sum
 	Avg
-	CountDistinct
 	Max
 	Min
+	CountDistinct
 	P99
 )
 

--- a/query/grouped_result.go
+++ b/query/grouped_result.go
@@ -1,0 +1,99 @@
+package query
+
+import "github.com/xichen2020/eventdb/document/field"
+
+// TransformFn transforms a list of raw calculated values into a final calculated value.
+// For example, computation of `Avg` should be transformed into computation of `Sum` and
+// `Count`, and once the results are gathered, the final `Avg` value can be computed as
+// `Sum` / `Count`.
+type TransformFn func(rawValues []float64) float64
+
+// CalculatedValue represents a calculated value. In simple cases this is simply a single
+// numeric value. However, there are also cases where calculation of a value requires
+// calculations of other intermediate values, which eventually get transformed into the
+// final calculated value (e.g., the average value of a field).
+type CalculatedValue struct {
+	Value       float64
+	Values      []float64
+	TransformFn TransformFn
+}
+
+// ResultGroup is a result group.
+type ResultGroup struct {
+	// Group key corresponding to the `GroupBy` fields in the query.
+	Key []field.ValueUnion
+
+	// Field values to order the groups by.
+	OrderByValues []field.ValueUnion
+
+	// A list of calculated values for a result group.
+	CalculatedValues []CalculatedValue
+}
+
+// GroupedResults is a collection of result groups.
+type GroupedResults struct {
+	OrderBy          []OrderBy
+	Limit            int
+	ValuesLessThanFn field.ValuesLessThanFn
+
+	// If `OrderBy` is not empty, the groups are sorted in the order dictated by the `OrderBy`
+	// clause in the query.
+	Groups []ResultGroup
+}
+
+// Len returns the number of grouped results.
+func (r *GroupedResults) Len() int { return len(r.Groups) }
+
+// IsOrdered returns true if the grouped results are kept in order.
+func (r *GroupedResults) IsOrdered() bool { return len(r.OrderBy) > 0 }
+
+// LimitReached returns true if we have collected enough grouped results.
+func (r *GroupedResults) LimitReached() bool { return r.Len() >= r.Limit }
+
+// MinOrderByValues returns the orderBy field values for the smallest result in
+// the result collection.
+func (r *GroupedResults) MinOrderByValues() []field.ValueUnion {
+	if r.Len() == 0 {
+		return nil
+	}
+	return r.Groups[0].OrderByValues
+}
+
+// MaxOrderByValues returns the orderBy field values for the largest result in
+// the result collection.
+func (r *GroupedResults) MaxOrderByValues() []field.ValueUnion {
+	if r.Len() == 0 {
+		return nil
+	}
+	return r.Groups[r.Len()-1].OrderByValues
+}
+
+// FieldValuesLessThanFn returns the function to compare two set of field values.
+func (r *GroupedResults) FieldValuesLessThanFn() field.ValuesLessThanFn {
+	return r.ValuesLessThanFn
+}
+
+// Add adds a result group to the collection.
+// For unordered grouped results:
+// - If the results have not reached limit yet, the incoming result is appended at the end.
+// - Otherwise, the incoming result is dropped.
+// For ordered grouped results:
+// - If the results have not reached limit yet, the incoming result is added in order.
+// - Otherwise, the incoming result is inserted and the last result is dropped.
+// TODO(xichen): Implement this.
+func (r *GroupedResults) Add(rr ResultGroup) {
+	panic("not implemented")
+}
+
+// AddBatch adds a batch of result groups to the collection.
+// For unordered grouped results, the incoming batch is unsorted:
+// - If the results have not reached limit yet, the incoming results are appended at the end
+//   until the limit is reached, after which the incoming results are dropped.
+// - Otherwise, the incoming results are dropped.
+// For ordered grouped results, the incoming batch is sorted:
+// - If the results have not reached limit yet, the incoming results are added in order
+//   until the limit is reached, after which the incoming results are inserted and
+//   the results beyond limit are dropped.
+func (r *GroupedResults) AddBatch(rr []ResultGroup) {
+	panic("not implemented")
+}

--- a/query/query.go
+++ b/query/query.go
@@ -87,7 +87,7 @@ type ParseOptions struct {
 
 // Parse parses the raw query, returning any errors encountered.
 func (q *RawQuery) Parse(opts ParseOptions) (ParsedQuery, error) {
-	var sq ParsedQuery
+	sq := ParsedQuery{opts: opts}
 
 	ns, err := q.parseNamespace()
 	if err != nil {
@@ -129,7 +129,7 @@ func (q *RawQuery) Parse(opts ParseOptions) (ParsedQuery, error) {
 	}
 	sq.Limit = limit
 
-	err = sq.computeDerived(opts)
+	err = sq.computeDerived()
 	return sq, err
 }
 
@@ -432,8 +432,9 @@ type ParsedQuery struct {
 	Limit           int
 
 	// Derived fields for raw query.
-	AllowedFieldTypes map[hash.Hash]FieldMeta
-	ValuesLessThanFn  field.ValuesLessThanFn
+	// AllowedFieldTypes map[hash.Hash]FieldMeta
+	opts             ParseOptions
+	valuesLessThanFn field.ValuesLessThanFn
 }
 
 // IsRaw returns true if the query is querying raw results (i.e., not grouped), and false otherwise.
@@ -443,64 +444,82 @@ func (q *ParsedQuery) IsRaw() bool { return len(q.GroupBy) == 0 }
 func (q *ParsedQuery) IsGrouped() bool { return !q.IsRaw() }
 
 // RawQuery returns the parsed raw query for raw results.
-func (q *ParsedQuery) RawQuery() ParsedRawQuery {
-	resultLessThanFn := func(r1, r2 RawResult) bool {
-		return q.ValuesLessThanFn(r1.OrderByValues, r2.OrderByValues)
-	}
-	resultReverseLessThanFn := func(r1, r2 RawResult) bool {
-		return !resultLessThanFn(r1, r2)
-	}
-	var requiredFieldPaths [][]string
-	if numRequiredFields := len(q.OrderBy); numRequiredFields > 0 {
-		requiredFieldPaths = make([][]string, 0, numRequiredFields)
-		for _, ob := range q.OrderBy {
-			requiredFieldPaths = append(requiredFieldPaths, ob.FieldPath)
-		}
-	}
-	return ParsedRawQuery{
-		Namespace:               q.Namespace,
-		StartNanosInclusive:     q.StartTimeNanos,
-		EndNanosExclusive:       q.EndTimeNanos,
-		Filters:                 q.Filters,
-		OrderBy:                 q.OrderBy,
-		Limit:                   q.Limit,
-		AllowedFieldTypes:       q.AllowedFieldTypes,
-		RequiredFieldPaths:      requiredFieldPaths,
-		ValuesLessThanFn:        q.ValuesLessThanFn,
-		ResultLessThanFn:        resultLessThanFn,
-		ResultReverseLessThanFn: resultReverseLessThanFn,
-	}
+func (q *ParsedQuery) RawQuery() (ParsedRawQuery, error) {
+	return newParsedRawQuery(q)
 }
 
 // GroupedQuery returns the parsed grouped query for grouped results.
 func (q *ParsedQuery) GroupedQuery() ParsedGroupedQuery {
-	var requiredFieldPaths [][]string
-	// NB: Fields in `OrderBy` must also appear either in `GroupBy` or in `Calculations`.
-	if numRequiredFields := len(q.GroupBy) + len(q.Calculations); numRequiredFields > 0 {
-		requiredFieldPaths = make([][]string, 0, numRequiredFields)
-		requiredFieldPaths = append(requiredFieldPaths, q.GroupBy...)
-		for _, calc := range q.Calculations {
-			if calc.FieldPath != nil {
-				requiredFieldPaths = append(requiredFieldPaths, calc.FieldPath)
-			}
+	return newParsedGroupedQuery(q)
+}
+
+func (q *ParsedQuery) computeDerived() error {
+	return q.computeValueCompareFns()
+}
+
+func (q *ParsedQuery) computeValueCompareFns() error {
+	compareFns := make([]field.ValueCompareFn, 0, len(q.OrderBy))
+	for _, ob := range q.OrderBy {
+		compareFn, err := ob.SortOrder.CompareFn()
+		if err != nil {
+			return fmt.Errorf("error determining the value compare fn for sort order %v: %v", ob.SortOrder, err)
 		}
+		compareFns = append(compareFns, compareFn)
 	}
-	return ParsedGroupedQuery{
-		Namespace:           q.Namespace,
-		StartNanosInclusive: q.StartTimeNanos,
-		EndNanosExclusive:   q.EndTimeNanos,
-		TimeGranularity:     q.TimeGranularity,
-		Filters:             q.Filters,
-		GroupBy:             q.GroupBy,
-		Calculations:        q.Calculations,
-		OrderBy:             q.OrderBy,
-		Limit:               q.Limit,
-		RequiredFieldPaths:  requiredFieldPaths,
-		ValuesLessThanFn:    q.ValuesLessThanFn,
+	q.valuesLessThanFn = field.NewValuesLessThanFn(compareFns)
+	return nil
+}
+
+// FieldMeta contains field metadata.
+type FieldMeta struct {
+	FieldPath               []string
+	AllowedTypesBySourceIdx map[int]field.ValueTypeSet
+}
+
+// MergeInPlace merges the other field meta into the current field meta.
+// Precondition: m.fieldPath == other.fieldPath.
+// Precondition: The set of source indices in the two metas don't overlap.
+func (m *FieldMeta) MergeInPlace(other FieldMeta) {
+	for idx, types := range other.AllowedTypesBySourceIdx {
+		m.AllowedTypesBySourceIdx[idx] = types
 	}
 }
 
-func (q *ParsedQuery) numFieldsForRawQuery() int {
+// ParsedRawQuery represents a validated, sanitized raw query.
+type ParsedRawQuery struct {
+	Namespace           string
+	StartNanosInclusive int64
+	EndNanosExclusive   int64
+	Filters             []FilterList
+	OrderBy             []OrderBy
+	Limit               int
+
+	// Derived fields.
+	ValuesLessThanFn        field.ValuesLessThanFn
+	ResultLessThanFn        RawResultLessThanFn
+	ResultReverseLessThanFn RawResultLessThanFn
+	AllowedFieldTypes       map[hash.Hash]FieldMeta
+	RequiredFieldPaths      [][]string
+}
+
+func newParsedRawQuery(q *ParsedQuery) (ParsedRawQuery, error) {
+	rq := ParsedRawQuery{
+		Namespace:           q.Namespace,
+		StartNanosInclusive: q.StartTimeNanos,
+		EndNanosExclusive:   q.EndTimeNanos,
+		Filters:             q.Filters,
+		OrderBy:             q.OrderBy,
+		Limit:               q.Limit,
+		ValuesLessThanFn:    q.valuesLessThanFn,
+	}
+	if err := rq.computeDerived(q.opts); err != nil {
+		return ParsedRawQuery{}, err
+	}
+	return rq, nil
+}
+
+// NumFieldsForQuery returns the total number of fields for query.
+func (q *ParsedRawQuery) NumFieldsForQuery() int {
 	numFieldsForQuery := 2 // Timestamp field and raw doc source field
 	for _, f := range q.Filters {
 		numFieldsForQuery += len(f.Filters)
@@ -509,23 +528,49 @@ func (q *ParsedQuery) numFieldsForRawQuery() int {
 	return numFieldsForQuery
 }
 
-func (q *ParsedQuery) computeDerived(opts ParseOptions) error {
-	if q.IsRaw() {
-		return q.computeRawDerived(opts)
+// NewRawResults creates a new raw results from the parsed raw query.
+func (q *ParsedRawQuery) NewRawResults() RawResults {
+	return RawResults{
+		OrderBy:                 q.OrderBy,
+		Limit:                   q.Limit,
+		ValuesLessThanFn:        q.ValuesLessThanFn,
+		ResultLessThanFn:        q.ResultLessThanFn,
+		ResultReverseLessThanFn: q.ResultReverseLessThanFn,
+		RequiredFieldPaths:      q.RequiredFieldPaths,
 	}
-	return q.computeGroupDerived(opts)
 }
 
-func (q *ParsedQuery) computeRawDerived(opts ParseOptions) error {
-	if err := q.computeRawAllowedFieldTypes(opts); err != nil {
-		return err
+// computeDerived computes the derived fields.
+func (q *ParsedRawQuery) computeDerived(opts ParseOptions) error {
+	q.ResultLessThanFn = func(r1, r2 RawResult) bool {
+		return q.ValuesLessThanFn(r1.OrderByValues, r2.OrderByValues)
 	}
-	return q.computeRawResultCompareFns()
+	q.ResultReverseLessThanFn = func(r1, r2 RawResult) bool {
+		return !q.ResultLessThanFn(r1, r2)
+	}
+	q.RequiredFieldPaths = q.computeRequiredFieldPaths()
+
+	var err error
+	q.AllowedFieldTypes, err = q.computeAllowedFieldTypes(opts)
+	return err
 }
 
-func (q *ParsedQuery) computeRawAllowedFieldTypes(opts ParseOptions) error {
+func (q *ParsedRawQuery) computeRequiredFieldPaths() [][]string {
+	var requiredFieldPaths [][]string
+	if numRequiredFields := len(q.OrderBy); numRequiredFields > 0 {
+		requiredFieldPaths = make([][]string, 0, numRequiredFields)
+		for _, ob := range q.OrderBy {
+			requiredFieldPaths = append(requiredFieldPaths, ob.FieldPath)
+		}
+	}
+	return requiredFieldPaths
+}
+
+func (q *ParsedRawQuery) computeAllowedFieldTypes(
+	opts ParseOptions,
+) (map[hash.Hash]FieldMeta, error) {
 	// Compute total number of fields involved in executing the query.
-	numFieldsForQuery := q.numFieldsForRawQuery()
+	numFieldsForQuery := q.NumFieldsForQuery()
 
 	// Collect fields needed for query execution into a map for deduplciation.
 	fieldMap := make(map[hash.Hash]FieldMeta, numFieldsForQuery)
@@ -558,7 +603,7 @@ func (q *ParsedQuery) computeRawAllowedFieldTypes(opts ParseOptions) error {
 		for _, f := range fl.Filters {
 			allowedFieldTypes, err := f.AllowedFieldTypes()
 			if err != nil {
-				return err
+				return nil, err
 			}
 			addQueryFieldToMap(fieldMap, opts.FieldHashFn, FieldMeta{
 				FieldPath: f.FieldPath,
@@ -581,8 +626,70 @@ func (q *ParsedQuery) computeRawAllowedFieldTypes(opts ParseOptions) error {
 		currIndex++
 	}
 
-	q.AllowedFieldTypes = fieldMap
-	return nil
+	return fieldMap, nil
+}
+
+// ParsedGroupedQuery represents a validated, sanitized group query.
+type ParsedGroupedQuery struct {
+	Namespace           string
+	StartNanosInclusive int64
+	EndNanosExclusive   int64
+	TimeGranularity     time.Duration
+	Filters             []FilterList
+	GroupBy             [][]string
+	Calculations        []Calculation
+	OrderBy             []OrderBy
+	Limit               int
+
+	// Derived fields.
+	RequiredFieldPaths [][]string
+	ValuesLessThanFn   field.ValuesLessThanFn
+}
+
+func newParsedGroupedQuery(q *ParsedQuery) ParsedGroupedQuery {
+	gq := ParsedGroupedQuery{
+		Namespace:           q.Namespace,
+		StartNanosInclusive: q.StartTimeNanos,
+		EndNanosExclusive:   q.EndTimeNanos,
+		TimeGranularity:     q.TimeGranularity,
+		Filters:             q.Filters,
+		GroupBy:             q.GroupBy,
+		Calculations:        q.Calculations,
+		OrderBy:             q.OrderBy,
+		Limit:               q.Limit,
+		ValuesLessThanFn:    q.valuesLessThanFn,
+	}
+	gq.computeDerived()
+	return gq
+}
+
+// NewGroupedResults creats a new grouped results from the parsed grouped query.
+func (q *ParsedGroupedQuery) NewGroupedResults() GroupedResults {
+	return GroupedResults{
+		OrderBy:            q.OrderBy,
+		Limit:              q.Limit,
+		ValuesLessThanFn:   q.ValuesLessThanFn,
+		RequiredFieldPaths: q.RequiredFieldPaths,
+	}
+}
+
+func (q *ParsedGroupedQuery) computeDerived() {
+	q.RequiredFieldPaths = q.computeRequiredFieldPaths()
+}
+
+func (q *ParsedGroupedQuery) computeRequiredFieldPaths() [][]string {
+	var requiredFieldPaths [][]string
+	// NB: Fields in `OrderBy` must also appear either in `GroupBy` or in `Calculations`.
+	if numRequiredFields := len(q.GroupBy) + len(q.Calculations); numRequiredFields > 0 {
+		requiredFieldPaths = make([][]string, 0, numRequiredFields)
+		requiredFieldPaths = append(requiredFieldPaths, q.GroupBy...)
+		for _, calc := range q.Calculations {
+			if calc.FieldPath != nil {
+				requiredFieldPaths = append(requiredFieldPaths, calc.FieldPath)
+			}
+		}
+	}
+	return requiredFieldPaths
 }
 
 // addQueryFieldToMap adds a new query field meta to the existing
@@ -604,105 +711,6 @@ func addQueryFieldToMap(
 	}
 	meta.MergeInPlace(newFieldMeta)
 	fm[fieldHash] = meta
-}
-
-func (q *ParsedQuery) computeRawResultCompareFns() error {
-	compareFns := make([]field.ValueCompareFn, 0, len(q.OrderBy))
-	for _, ob := range q.OrderBy {
-		compareFn, err := ob.SortOrder.CompareFn()
-		if err != nil {
-			return fmt.Errorf("error determining the value compare fn for sort order %v: %v", ob.SortOrder, err)
-		}
-		compareFns = append(compareFns, compareFn)
-	}
-	q.ValuesLessThanFn = field.NewValuesLessThanFn(compareFns)
-	return nil
-}
-
-// TODO(xichen): Implement this if necessary.
-func (q *ParsedQuery) computeGroupDerived(opts ParseOptions) error {
-	return nil
-}
-
-// FieldMeta contains field metadata.
-type FieldMeta struct {
-	FieldPath               []string
-	AllowedTypesBySourceIdx map[int]field.ValueTypeSet
-}
-
-// MergeInPlace merges the other field meta into the current field meta.
-// Precondition: m.fieldPath == other.fieldPath.
-// Precondition: The set of source indices in the two metas don't overlap.
-func (m *FieldMeta) MergeInPlace(other FieldMeta) {
-	for idx, types := range other.AllowedTypesBySourceIdx {
-		m.AllowedTypesBySourceIdx[idx] = types
-	}
-}
-
-// ParsedRawQuery represents a validated, sanitized raw query.
-type ParsedRawQuery struct {
-	Namespace           string
-	StartNanosInclusive int64
-	EndNanosExclusive   int64
-	Filters             []FilterList
-	OrderBy             []OrderBy
-	Limit               int
-
-	// Derived fields.
-	AllowedFieldTypes       map[hash.Hash]FieldMeta
-	RequiredFieldPaths      [][]string
-	ValuesLessThanFn        field.ValuesLessThanFn
-	ResultLessThanFn        RawResultLessThanFn
-	ResultReverseLessThanFn RawResultLessThanFn
-}
-
-// NumFieldsForQuery returns the total number of fields for query.
-func (q *ParsedRawQuery) NumFieldsForQuery() int {
-	numFieldsForQuery := 2 // Timestamp field and raw doc source field
-	for _, f := range q.Filters {
-		numFieldsForQuery += len(f.Filters)
-	}
-	numFieldsForQuery += len(q.OrderBy)
-	return numFieldsForQuery
-}
-
-// NewRawResults creates a new raw results from the parsed raw query.
-func (q *ParsedRawQuery) NewRawResults() RawResults {
-	return RawResults{
-		OrderBy:                 q.OrderBy,
-		Limit:                   q.Limit,
-		ValuesLessThanFn:        q.ValuesLessThanFn,
-		ResultLessThanFn:        q.ResultLessThanFn,
-		ResultReverseLessThanFn: q.ResultReverseLessThanFn,
-		RequiredFieldPaths:      q.RequiredFieldPaths,
-	}
-}
-
-// ParsedGroupedQuery represents a validated, sanitized group query.
-type ParsedGroupedQuery struct {
-	Namespace           string
-	StartNanosInclusive int64
-	EndNanosExclusive   int64
-	TimeGranularity     time.Duration
-	Filters             []FilterList
-	GroupBy             [][]string
-	Calculations        []Calculation
-	OrderBy             []OrderBy
-	Limit               int
-
-	// Derived fields.
-	RequiredFieldPaths [][]string
-	ValuesLessThanFn   field.ValuesLessThanFn
-}
-
-// NewGroupedResults creats a new grouped results from the parsed grouped query.
-func (q *ParsedGroupedQuery) NewGroupedResults() GroupedResults {
-	return GroupedResults{
-		OrderBy:            q.OrderBy,
-		Limit:              q.Limit,
-		ValuesLessThanFn:   q.ValuesLessThanFn,
-		RequiredFieldPaths: q.RequiredFieldPaths,
-	}
 }
 
 // Calculation represents a calculation object.

--- a/query/raw_result.go
+++ b/query/raw_result.go
@@ -186,6 +186,7 @@ type RawResults struct {
 	ValuesLessThanFn        field.ValuesLessThanFn
 	ResultLessThanFn        RawResultLessThanFn
 	ResultReverseLessThanFn RawResultLessThanFn
+	RequiredFieldPaths      [][]string
 
 	Data  []RawResult `json:"data"`
 	cache []RawResult
@@ -199,6 +200,13 @@ func (r *RawResults) IsOrdered() bool { return len(r.OrderBy) > 0 }
 
 // LimitReached returns true if we have collected enough raw results.
 func (r *RawResults) LimitReached() bool { return r.Len() >= r.Limit }
+
+// IsComplete returns true if the query result is complete and can be returned
+// immediately without performing any further subqueries if any. This currently
+// means the result should be unordered and the result collection size has reached
+// the size limit. For ordered results, we should continue performing the subqueries
+// if any since there may be future results that are ordered higher than the current results.
+func (r *RawResults) IsComplete() bool { return r.LimitReached() && !r.IsOrdered() }
 
 // MinOrderByValues returns the orderBy field values for the smallest result in
 // the result collection.
@@ -222,6 +230,9 @@ func (r *RawResults) MaxOrderByValues() []field.ValueUnion {
 func (r *RawResults) FieldValuesLessThanFn() field.ValuesLessThanFn {
 	return r.ValuesLessThanFn
 }
+
+// RequiredFields returns the field paths for required fields.
+func (r *RawResults) RequiredFields() [][]string { return r.RequiredFieldPaths }
 
 // Add adds a raw result to the collection.
 // For unordered raw results:

--- a/query/result.go
+++ b/query/result.go
@@ -1,0 +1,26 @@
+package query
+
+import "github.com/xichen2020/eventdb/document/field"
+
+// BaseResults represent query result collection.
+type BaseResults interface {
+	// Len returns the number of invidiual results in the result collection.
+	Len() int
+
+	// IsOrdered returns true if the results are ordered, and false otherwise.
+	IsOrdered() bool
+
+	// LimitReached returns true if the result collection has reached specified limit.
+	LimitReached() bool
+
+	// MinOrderByValues returns the orderBy field values for the smallest result in
+	// the result collection.
+	MinOrderByValues() []field.ValueUnion
+
+	// MaxOrderByValues returns the orderBy field values for the largest result in
+	// the result collection.
+	MaxOrderByValues() []field.ValueUnion
+
+	// FieldValuesLessThanFn returns the function to compare two set of field values.
+	FieldValuesLessThanFn() field.ValuesLessThanFn
+}

--- a/query/result.go
+++ b/query/result.go
@@ -13,6 +13,9 @@ type BaseResults interface {
 	// LimitReached returns true if the result collection has reached specified limit.
 	LimitReached() bool
 
+	// IsComplete returns true if the result collection is complete.
+	IsComplete() bool
+
 	// MinOrderByValues returns the orderBy field values for the smallest result in
 	// the result collection.
 	MinOrderByValues() []field.ValueUnion
@@ -23,4 +26,7 @@ type BaseResults interface {
 
 	// FieldValuesLessThanFn returns the function to compare two set of field values.
 	FieldValuesLessThanFn() field.ValuesLessThanFn
+
+	// RequiredFields returns the field paths for required fields.
+	RequiredFields() [][]string
 }

--- a/storage/database.go
+++ b/storage/database.go
@@ -36,6 +36,13 @@ type Database interface {
 		q query.ParsedRawQuery,
 	) (query.RawResults, error)
 
+	// QueryGrouped executes a grouped query against database for documents matching
+	// certain criteria, with optional filtering, grouping, sorting, and limiting applied.
+	QueryGrouped(
+		ctx context.Context,
+		q query.ParsedGroupedQuery,
+	) (query.GroupedResults, error)
+
 	// Close closes the database.
 	Close() error
 }
@@ -153,6 +160,17 @@ func (d *db) QueryRaw(
 		return query.RawResults{}, err
 	}
 	return n.QueryRaw(ctx, q)
+}
+
+func (d *db) QueryGrouped(
+	ctx context.Context,
+	q query.ParsedGroupedQuery,
+) (query.GroupedResults, error) {
+	n, err := d.namespaceFor(unsafe.ToBytes(q.Namespace))
+	if err != nil {
+		return query.GroupedResults{}, err
+	}
+	return n.QueryGrouped(ctx, q)
 }
 
 func (d *db) Close() error {

--- a/storage/immutable_segment.go
+++ b/storage/immutable_segment.go
@@ -31,6 +31,17 @@ type immutableSegment interface {
 		res *query.RawResults,
 	) error
 
+	// QueryGrouped queries results for a given grouped query.
+	// Existing results if any (e.g., from querying other segments) are passed in `res`
+	// to help facilitate fast elimination of segments that do not have eligible records
+	// for the given query. The results from the current segment if any are merged with
+	// those in `res` upon completion.
+	QueryGrouped(
+		ctx context.Context,
+		q query.ParsedGroupedQuery,
+		res *query.GroupedResults,
+	) error
+
 	// LoadedStatus returns the segment loaded status.
 	LoadedStatus() segmentLoadedStatus
 
@@ -171,7 +182,7 @@ func (s *immutableSeg) QueryRaw(
 	q query.ParsedRawQuery,
 	res *query.RawResults,
 ) error {
-	shouldExit, err := s.checkForFastExit(q, res)
+	shouldExit, err := s.checkForFastExit(q.OrderBy, q.Limit, res)
 	if err != nil {
 		return err
 	}
@@ -234,6 +245,23 @@ func (s *immutableSeg) QueryRaw(
 		q,
 		res,
 	)
+}
+
+func (s *immutableSeg) QueryGrouped(
+	ctx context.Context,
+	q query.ParsedGroupedQuery,
+	res *query.GroupedResults,
+) error {
+	shouldExit, err := s.checkForFastExit(q.OrderBy, q.Limit, res)
+	if err != nil {
+		return err
+	}
+	if shouldExit {
+		return nil
+	}
+
+	// TODO(xichen): Finish implementation.
+	return errors.New("not implemented")
 }
 
 func (s *immutableSeg) LoadedStatus() segmentLoadedStatus {
@@ -326,11 +354,12 @@ func (s *immutableSeg) Close() {
 // checkForFastExit checks if the current segment should be queried,
 // returns true if not to reduce computation work, and false otherwise.
 func (s *immutableSeg) checkForFastExit(
-	q query.ParsedRawQuery,
-	res *query.RawResults,
+	orderBy []query.OrderBy,
+	limit int,
+	res query.BaseResults,
 ) (bool, error) {
 	// Fast path if the limit indicates no results are needed.
-	if q.Limit <= 0 {
+	if limit <= 0 {
 		return true, nil
 	}
 
@@ -343,11 +372,13 @@ func (s *immutableSeg) checkForFastExit(
 	}
 
 	var (
-		hasExistingResults = len(res.Data) > 0
-		minOrderByValues   []field.ValueUnion
-		maxOrderByValues   []field.ValueUnion
+		hasExistingResults       = res.Len() > 0
+		minExistingOrderByValues = res.MinOrderByValues()
+		maxExistingOrderByValues = res.MaxOrderByValues()
+		minOrderByValues         []field.ValueUnion
+		maxOrderByValues         []field.ValueUnion
 	)
-	for i, ob := range res.OrderBy {
+	for i, ob := range orderBy {
 		orderByFieldHash := s.fieldHashFn(ob.FieldPath)
 		entry, exists := s.entries[orderByFieldHash]
 		if !exists {
@@ -364,9 +395,9 @@ func (s *immutableSeg) checkForFastExit(
 		if !hasExistingResults {
 			continue
 		}
-		if res.Data[0].OrderByValues[i].Type != availableTypes[0] {
+		if minExistingOrderByValues[i].Type != availableTypes[0] {
 			// We expect the orderBy fields to have consistent types.
-			return false, fmt.Errorf("order by field have type %v in the results and type %v in the segment", res.Data[0].OrderByValues[i].Type, availableTypes[0])
+			return false, fmt.Errorf("order by field have type %v in the results and type %v in the segment", minExistingOrderByValues[i].Type, availableTypes[0])
 		}
 		if !res.LimitReached() {
 			continue
@@ -377,8 +408,8 @@ func (s *immutableSeg) checkForFastExit(
 			return false, err
 		}
 		if minOrderByValues == nil {
-			minOrderByValues = make([]field.ValueUnion, 0, len(res.OrderBy))
-			maxOrderByValues = make([]field.ValueUnion, 0, len(res.OrderBy))
+			minOrderByValues = make([]field.ValueUnion, 0, len(orderBy))
+			maxOrderByValues = make([]field.ValueUnion, 0, len(orderBy))
 		}
 		if ob.SortOrder == query.Ascending {
 			minOrderByValues = append(minOrderByValues, minUnion)
@@ -393,20 +424,14 @@ func (s *immutableSeg) checkForFastExit(
 		return false, nil
 	}
 
-	var (
-		minExistingRes = res.Data[0]
-		maxExistingRes = res.Data[len(res.Data)-1]
-	)
-
+	valuesLessThanFn := res.FieldValuesLessThanFn()
 	// Assert the values of all orderBy fields are within the bounds of existing results.
-	minRawResult := query.RawResult{OrderByValues: minOrderByValues}
-	if res.LessThanFn(maxExistingRes, minRawResult) {
+	if valuesLessThanFn(maxExistingOrderByValues, minOrderByValues) {
 		// If the maximum existing result is less than the minimum raw result in this segment,
 		// there is no need to query this segment as we've gathered enough raw results.
 		return true, nil
 	}
-	maxRawResult := query.RawResult{OrderByValues: maxOrderByValues}
-	if res.LessThanFn(maxRawResult, minExistingRes) {
+	if valuesLessThanFn(maxOrderByValues, minExistingOrderByValues) {
 		// If the maximum raw result in this segment is less than the minimum existing result,
 		// there is no need to query this segment as we've gathered enough raw results.
 		return true, nil

--- a/storage/mutable_segment.go
+++ b/storage/mutable_segment.go
@@ -25,6 +25,12 @@ type mutableSegment interface {
 		q query.ParsedRawQuery,
 	) ([]query.RawResult, error)
 
+	// QueryGrouped returns results for a given grouped query.
+	QueryGrouped(
+		ctx context.Context,
+		q query.ParsedGroupedQuery,
+	) ([]query.ResultGroup, error)
+
 	// IsFull returns true if the number of documents in the segment has reached
 	// the maximum threshold.
 	IsFull() bool
@@ -242,6 +248,13 @@ func (s *mutableSeg) QueryRaw(
 		return nil, err
 	}
 	return rawResult.Data, nil
+}
+
+func (s *mutableSeg) QueryGrouped(
+	ctx context.Context,
+	q query.ParsedGroupedQuery,
+) ([]query.ResultGroup, error) {
+	return nil, errors.New("not implemented")
 }
 
 func (s *mutableSeg) IsFull() bool {

--- a/storage/namespace.go
+++ b/storage/namespace.go
@@ -128,7 +128,7 @@ func (n *dbNamespace) QueryRaw(
 			return query.RawResults{}, err
 		}
 		res.AddBatch(shardRes.Data)
-		if !res.IsOrdered() && res.LimitReached() {
+		if res.IsComplete() {
 			// We've got enough data, bail early.
 			break
 		}
@@ -153,7 +153,7 @@ func (n *dbNamespace) QueryGrouped(
 			return query.GroupedResults{}, err
 		}
 		res.AddBatch(shardRes.Groups)
-		if !res.IsOrdered() && res.LimitReached() {
+		if res.IsComplete() {
 			// We've got enough data, bail early.
 			break
 		}

--- a/storage/namespace.go
+++ b/storage/namespace.go
@@ -32,6 +32,12 @@ type databaseNamespace interface {
 		q query.ParsedRawQuery,
 	) (query.RawResults, error)
 
+	// QueryGrouped performs a group query against the documents in the namespace.
+	QueryGrouped(
+		ctx context.Context,
+		q query.ParsedGroupedQuery,
+	) (query.GroupedResults, error)
+
 	// Tick performs a tick against the namespace.
 	Tick(ctx context.Context) error
 
@@ -122,6 +128,31 @@ func (n *dbNamespace) QueryRaw(
 			return query.RawResults{}, err
 		}
 		res.AddBatch(shardRes.Data)
+		if !res.IsOrdered() && res.LimitReached() {
+			// We've got enough data, bail early.
+			break
+		}
+	}
+	return res, nil
+}
+
+func (n *dbNamespace) QueryGrouped(
+	ctx context.Context,
+	q query.ParsedGroupedQuery,
+) (query.GroupedResults, error) {
+	retentionStartNanos := n.nowFn().Add(-n.nsOpts.Retention()).UnixNano()
+	if q.StartNanosInclusive < retentionStartNanos {
+		q.StartNanosInclusive = retentionStartNanos
+	}
+
+	res := q.NewGroupedResults()
+	shards := n.getOwnedShards()
+	for _, shard := range shards {
+		shardRes, err := shard.QueryGrouped(ctx, q)
+		if err != nil {
+			return query.GroupedResults{}, err
+		}
+		res.AddBatch(shardRes.Groups)
 		if !res.IsOrdered() && res.LimitReached() {
 			// We've got enough data, bail early.
 			break

--- a/storage/sealed_segment.go
+++ b/storage/sealed_segment.go
@@ -35,6 +35,13 @@ type sealedSegment interface {
 		res *query.RawResults,
 	) error
 
+	// QueryGrouped returns results for a given grouped query.
+	QueryGrouped(
+		ctx context.Context,
+		q query.ParsedGroupedQuery,
+		res *query.GroupedResults,
+	) error
+
 	// ShouldUnload returns true if the segment is eligible for unloading.
 	ShouldUnload() bool
 
@@ -102,6 +109,16 @@ func (s *sealedFlushingSeg) QueryRaw(
 	res *query.RawResults,
 ) error {
 	err := s.immutableSegment.QueryRaw(ctx, q, res)
+	atomic.StoreInt64(&s.lastReadAtNanos, s.nowFn().UnixNano())
+	return err
+}
+
+func (s *sealedFlushingSeg) QueryGrouped(
+	ctx context.Context,
+	q query.ParsedGroupedQuery,
+	res *query.GroupedResults,
+) error {
+	err := s.immutableSegment.QueryGrouped(ctx, q, res)
 	atomic.StoreInt64(&s.lastReadAtNanos, s.nowFn().UnixNano())
 	return err
 }

--- a/storage/segment_query.go
+++ b/storage/segment_query.go
@@ -207,7 +207,7 @@ func collectOrderedRawDocSourceData(
 
 	orderedRawResults, err := collectTopNRawResultDocIDOrderByValues(
 		filteredOrderByIter,
-		q.RawResultReverseLessThanFn,
+		q.ResultReverseLessThanFn,
 		q.Limit,
 	)
 	if err != nil {

--- a/storage/shard.go
+++ b/storage/shard.go
@@ -168,7 +168,7 @@ func (s *dbShard) QueryRaw(
 	}
 	res := q.NewRawResults()
 	res.AddBatch(activeRes)
-	if !res.IsOrdered() && res.LimitReached() {
+	if res.IsComplete() {
 		return res, nil
 	}
 
@@ -177,7 +177,7 @@ func (s *dbShard) QueryRaw(
 		if err := ss.QueryRaw(ctx, q, &res); err != nil {
 			return query.RawResults{}, err
 		}
-		if !res.IsOrdered() && res.LimitReached() {
+		if res.IsComplete() {
 			return res, nil
 		}
 	}
@@ -212,7 +212,7 @@ func (s *dbShard) QueryGrouped(
 	}
 	res := q.NewGroupedResults()
 	res.AddBatch(activeRes)
-	if !res.IsOrdered() && res.LimitReached() {
+	if res.IsComplete() {
 		return res, nil
 	}
 
@@ -221,7 +221,7 @@ func (s *dbShard) QueryGrouped(
 		if err := ss.QueryGrouped(ctx, q, &res); err != nil {
 			return query.GroupedResults{}, err
 		}
-		if !res.IsOrdered() && res.LimitReached() {
+		if res.IsComplete() {
 			return res, nil
 		}
 	}

--- a/storage/shard_test.go
+++ b/storage/shard_test.go
@@ -77,6 +77,12 @@ type mockImmutableSegment struct {
 		res *query.RawResults,
 	) error
 
+	queryGroupedFn func(
+		ctx context.Context,
+		q query.ParsedGroupedQuery,
+		res *query.GroupedResults,
+	) error
+
 	loadedStatusFn func() segmentLoadedStatus
 	unloadFn       func() error
 	flushFn        func(persistFns persist.Fns) error
@@ -88,6 +94,14 @@ func (m *mockImmutableSegment) QueryRaw(
 	res *query.RawResults,
 ) error {
 	return m.queryRawFn(ctx, q, res)
+}
+
+func (m *mockImmutableSegment) QueryGrouped(
+	ctx context.Context,
+	q query.ParsedGroupedQuery,
+	res *query.GroupedResults,
+) error {
+	return m.queryGroupedFn(ctx, q, res)
 }
 
 func (m *mockImmutableSegment) LoadedStatus() segmentLoadedStatus {


### PR DESCRIPTION
cc @notbdu @black-adder 

This PR defines the group query types and adds the initial logic to thread the grouped query API through the storage layer.