### PR TITLE
Fix field indexing

### DIFF
--- a/storage/immutable_segment.go
+++ b/storage/immutable_segment.go
@@ -218,10 +218,11 @@ func (s *immutableSeg) QueryRaw(
 		}
 	}()
 
-	if queryFields[rawDocSourceFieldIdx] == nil {
+	queryRawDocSourceFieldIdx := fieldIndexMap[rawDocSourceFieldIdx]
+	if queryFields[queryRawDocSourceFieldIdx] == nil {
 		return errNoRawDocSourceField
 	}
-	rawDocSourceField, ok := queryFields[rawDocSourceFieldIdx].StringField()
+	rawDocSourceField, ok := queryFields[queryRawDocSourceFieldIdx].StringField()
 	if !ok {
 		return errNoStringValuesInRawDocSourceField
 	}

--- a/storage/mutable_segment.go
+++ b/storage/mutable_segment.go
@@ -213,10 +213,11 @@ func (s *mutableSeg) QueryRaw(
 		return nil, nil
 	}
 
-	if queryFields[rawDocSourceFieldIdx] == nil {
+	queryRawDocSourceFieldIdx := fieldIndexMap[rawDocSourceFieldIdx]
+	if queryFields[queryRawDocSourceFieldIdx] == nil {
 		return nil, errNoRawDocSourceField
 	}
-	rawDocSourceField, ok := queryFields[rawDocSourceFieldIdx].StringField()
+	rawDocSourceField, ok := queryFields[queryRawDocSourceFieldIdx].StringField()
 	if !ok {
 		return nil, errNoStringValuesInRawDocSourceField
 	}

--- a/storage/segment_query.go
+++ b/storage/segment_query.go
@@ -55,8 +55,8 @@ func applyFilters(
 	queryFields []indexfield.DocsField,
 	numTotalDocs int32,
 ) (index.DocIDSetIterator, error) {
-	timestampFieldIdx := fieldIndexMap[timestampFieldIdx]
-	timestampField, exists := queryFields[timestampFieldIdx].TimeField()
+	queryTimestampFieldIdx := fieldIndexMap[timestampFieldIdx]
+	timestampField, exists := queryFields[queryTimestampFieldIdx].TimeField()
 	if !exists {
 		return nil, errNoTimeValuesInTimestampField
 	}


### PR DESCRIPTION
cc @black-adder 

This PR fixes how we index into `queryFields` by using `fieldIndexMap` to first map the source indices to the target index in `queryFields`, and then use the target index to index into `queryFields`.