### PR TITLE
Add a duration type that can be unmarshalled from JSON

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7cb7b0c68d076ab28ed1aea4fabf52e562916935894b8063c08c35353626b774
-updated: 2019-02-01T15:57:54.514572-05:00
+hash: 391841f87dbc4a2ce6cdb3240efaa7d6bd12b5dd6fbe0353f13cbdcd98ec45d0
+updated: 2019-02-05T21:36:43.473522-05:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -139,12 +139,21 @@ imports:
   version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448
   repo: https://github.com/go-validator/validator.git
 - name: gopkg.in/yaml.v2
-  version: 51d6538a90f86fe93ac480b35f37b2be17fef232
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
+  repo: https://github.com/go-yaml/yaml.git
 testImports:
 - name: github.com/glycerine/go-unsnap-stream
   version: f9677308dec2b35e76737f9713df328ad11b1fea
 - name: github.com/golang/snappy
   version: 2e65f85255dbc3072edf28d6b5b8efc472979f5a
+- name: github.com/google/go-cmp
+  version: 3af367b6b30c263d47e8895973edcca9a49cf029
+  subpackages:
+  - cmp
+  - cmp/cmpopts
+  - cmp/internal/diff
+  - cmp/internal/function
+  - cmp/internal/value
 - name: github.com/mschoch/smat
   version: 90eadee771aeab36e8bf796039b8c261bebebe4f
 - name: github.com/philhofer/fwd

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,8 +11,6 @@ import:
   - protoc-gen-gofast
 - package: github.com/valyala/gozstd
   version: ^1.1.0
-- package: gopkg.in/yaml.v2
-  version: ~2.2.2
 - package: github.com/dgryski/go-bitstream
   version: 3522498ce2c8ea06df73e55df58edfbfb33cfdd6
 - package: github.com/willf/bitset

--- a/query/unparsed_query_test.go
+++ b/query/unparsed_query_test.go
@@ -1,0 +1,130 @@
+package query
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/xichen2020/eventdb/calculation"
+	"github.com/xichen2020/eventdb/document/field"
+	"github.com/xichen2020/eventdb/filter"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnparsedGroupByQueryParse(t *testing.T) {
+	input := `{
+"namespace": "foo",
+"end_time": 9876,
+"time_range": "1h",
+"filters": [
+  {
+    "filters": [
+      {
+        "field": "field1.field11",
+        "op": "=",
+        "value": "value1"
+      },
+      {
+        "field": "field2",
+        "op": ">",
+        "value": "value2"
+      }
+    ],
+    "filter_combinator": "AND"
+  }
+],
+"group_by": [
+  "field3.field31",
+  "field4"
+],
+"calculations": [
+  {
+    "op": "COUNT"
+  },
+  {
+    "op": "AVG",
+    "field": "field5"
+  }
+],
+"order_by": [
+  {
+    "field": "field3.field31",
+    "order": "ascending"
+  },
+  {
+    "field": "field5",
+    "op": "AVG",
+    "order": "descending"
+  }
+],
+"limit": 10
+}`
+
+	var (
+		valueUnion1 = field.NewStringUnion("value1")
+		valueUnion2 = field.NewStringUnion("value2")
+	)
+	expected := ParsedQuery{
+		Namespace:      "foo",
+		StartTimeNanos: 6276000000000,
+		EndTimeNanos:   9876000000000,
+		Filters: []FilterList{
+			{
+				Filters: []Filter{
+					{
+						FieldPath: []string{"field1", "field11"},
+						Op:        filter.Equals,
+						Value:     &valueUnion1,
+					},
+					{
+						FieldPath: []string{"field2"},
+						Op:        filter.LargerThan,
+						Value:     &valueUnion2,
+					},
+				},
+				FilterCombinator: filter.And,
+			},
+		},
+		GroupBy: [][]string{
+			{"field3", "field31"},
+			{"field4"},
+		},
+		Calculations: []Calculation{
+			{
+				Op: calculation.Count,
+			},
+			{
+				Op:        calculation.Avg,
+				FieldPath: []string{"field5"},
+			},
+		},
+		OrderBy: []OrderBy{
+			{
+				FieldType:  GroupByField,
+				FieldIndex: 0,
+				FieldPath:  []string{"field3", "field31"},
+				SortOrder:  Ascending,
+			},
+			{
+				FieldType:  CalculationField,
+				FieldIndex: 1,
+				FieldPath:  []string{"field5"},
+				SortOrder:  Descending,
+			},
+		},
+		Limit: 10,
+	}
+
+	var p UnparsedQuery
+	err := json.Unmarshal([]byte(input), &p)
+	require.NoError(t, err)
+	parsed, err := p.Parse(ParseOptions{
+		FieldPathSeparator: byte('.'),
+	})
+	require.NoError(t, err)
+
+	queryCmpOpts := cmpopts.IgnoreUnexported(ParsedQuery{})
+	require.True(t, cmp.Equal(expected, parsed, queryCmpOpts))
+}

--- a/x/time/duration.go
+++ b/x/time/duration.go
@@ -1,0 +1,31 @@
+package time
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Duration is a time duration that can be unmarshalled from JSON.
+type Duration time.Duration
+
+// String returns the duration string.
+func (d Duration) String() string { return time.Duration(d).String() }
+
+// MarshalJSON marshals the duration as a string.
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(d).String())
+}
+
+// UnmarshalJSON unmarshals the raw bytes into a duration.
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	dur, err := time.ParseDuration(v)
+	if err != nil {
+		return err
+	}
+	*d = Duration(dur)
+	return nil
+}

--- a/x/time/duration_test.go
+++ b/x/time/duration_test.go
@@ -1,0 +1,62 @@
+package time
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDurationMarshalJSON(t *testing.T) {
+	inputs := []struct {
+		dur      time.Duration
+		expected string
+	}{
+		{
+			dur:      time.Second,
+			expected: `"1s"`,
+		},
+		{
+			dur:      5 * time.Minute,
+			expected: `"5m0s"`,
+		},
+		{
+			dur:      2 * time.Hour,
+			expected: `"2h0m0s"`,
+		},
+	}
+
+	for _, input := range inputs {
+		b, err := json.Marshal(Duration(input.dur))
+		require.NoError(t, err)
+		require.Equal(t, input.expected, string(b))
+	}
+}
+
+func TestDurationUnmarshalJSON(t *testing.T) {
+	inputs := []struct {
+		expected time.Duration
+		str      string
+	}{
+		{
+			str:      `"1s"`,
+			expected: time.Second,
+		},
+		{
+			str:      `"5m"`,
+			expected: 5 * time.Minute,
+		},
+		{
+			str:      `"2h"`,
+			expected: 2 * time.Hour,
+		},
+	}
+
+	for _, input := range inputs {
+		var dur Duration
+		err := json.Unmarshal([]byte(input.str), &dur)
+		require.NoError(t, err)
+		require.Equal(t, input.expected, time.Duration(dur))
+	}
+}


### PR DESCRIPTION
cc @black-adder @notbdu 

This PR adds a `xtime.Duration` type to facilitate unmarshalling time durations from JSON. Also fixes a panic when only `time_range` is specified in query and adds a comprehensive unit test.