### PR TITLE
Remove interface conversion cost

### DIFF
--- a/values/decoding/bool_decode.go
+++ b/values/decoding/bool_decode.go
@@ -2,11 +2,11 @@ package decoding
 
 import (
 	"bytes"
+	"io"
 
 	"github.com/xichen2020/eventdb/generated/proto/encodingpb"
 	"github.com/xichen2020/eventdb/values"
 	"github.com/xichen2020/eventdb/values/iterator"
-	xio "github.com/xichen2020/eventdb/x/io"
 	xproto "github.com/xichen2020/eventdb/x/proto"
 )
 
@@ -46,7 +46,7 @@ func newBoolIteratorFromMeta(
 	return runLengthDecodeBool(readBool, reader), nil
 }
 
-func readBool(reader xio.Reader) (bool, error) {
+func readBool(reader io.ByteReader) (bool, error) {
 	var value bool
 	b, err := reader.ReadByte()
 	if err != nil {

--- a/values/decoding/dictionary_based_string_iterator.go
+++ b/values/decoding/dictionary_based_string_iterator.go
@@ -4,14 +4,12 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-
-	xio "github.com/xichen2020/eventdb/x/io"
 )
 
 // dictionaryBasedStringIterator iterates over a
 // dict encoded stream of string data.
 type dictionaryBasedStringIterator struct {
-	reader xio.Reader
+	reader io.ByteReader
 	// extDict is passed externally from the string decoder
 	// and should not be mutated during iteration.
 	extDict []string
@@ -21,7 +19,7 @@ type dictionaryBasedStringIterator struct {
 }
 
 func newDictionaryBasedStringIterator(
-	reader xio.Reader,
+	reader io.ByteReader,
 	extDict []string,
 ) *dictionaryBasedStringIterator {
 	return &dictionaryBasedStringIterator{

--- a/values/decoding/raw_size_string_iterator.go
+++ b/values/decoding/raw_size_string_iterator.go
@@ -17,7 +17,8 @@ const (
 // raw size encoded string data.
 // TODO(xichen): Get the buffer from bytes pool.
 type rawSizeStringIterator struct {
-	reader xio.Reader
+	reader     xio.Reader
+	byteReader io.ByteReader // Same as `reader` but has the proper type to save interface conversions in `Next`
 
 	curr string
 	err  error
@@ -28,8 +29,9 @@ func newRawSizeStringIterator(
 	reader xio.Reader,
 ) *rawSizeStringIterator {
 	return &rawSizeStringIterator{
-		reader: reader,
-		buf:    make([]byte, defaultInitialStringBufferCapacity),
+		reader:     reader,
+		byteReader: reader,
+		buf:        make([]byte, defaultInitialStringBufferCapacity),
 	}
 }
 
@@ -40,7 +42,7 @@ func (it *rawSizeStringIterator) Next() bool {
 	}
 
 	var rawSizeBytes int64
-	rawSizeBytes, it.err = binary.ReadVarint(it.reader)
+	rawSizeBytes, it.err = binary.ReadVarint(it.byteReader)
 	if it.err != nil {
 		return false
 	}
@@ -73,4 +75,5 @@ func (it *rawSizeStringIterator) Close() {
 	it.buf = nil
 	it.err = nil
 	it.reader = nil
+	it.byteReader = nil
 }

--- a/values/decoding/run_length_decode_bool.gen.go
+++ b/values/decoding/run_length_decode_bool.gen.go
@@ -10,8 +10,6 @@ import (
 	"errors"
 
 	"io"
-
-	xio "github.com/xichen2020/eventdb/x/io"
 )
 
 var (
@@ -19,19 +17,19 @@ var (
 )
 
 // readValueFn reads a value from reader.
-type readValueFn func(reader xio.Reader) (bool, error)
+type readValueFn func(reader io.ByteReader) (bool, error)
 
 // runLengthDecodeBool run length decodes a stream of Bools.
 func runLengthDecodeBool(
 	readValueFn readValueFn,
-	reader xio.Reader,
+	reader io.ByteReader,
 ) *runLengthBoolIterator {
 	return newRunLengthBoolIterator(reader, readValueFn)
 }
 
 // runLengthBoolIterator iterates over a run length encoded stream of values.
 type runLengthBoolIterator struct {
-	reader      xio.Reader
+	reader      io.ByteReader
 	readValueFn readValueFn
 
 	curr        bool
@@ -87,7 +85,7 @@ func (it *runLengthBoolIterator) Close() {
 }
 
 func newRunLengthBoolIterator(
-	reader xio.Reader,
+	reader io.ByteReader,
 	readValueFn readValueFn,
 ) *runLengthBoolIterator {
 	return &runLengthBoolIterator{

--- a/values/decoding/varint_int_iterator.go
+++ b/values/decoding/varint_int_iterator.go
@@ -3,21 +3,19 @@ package decoding
 import (
 	"encoding/binary"
 	"io"
-
-	xio "github.com/xichen2020/eventdb/x/io"
 )
 
 // varintIntIterator iterates over a stream of
 // varint encoded int data.
 type varintIntIterator struct {
-	reader xio.Reader
+	reader io.ByteReader
 
 	closed bool
 	curr   int
 	err    error
 }
 
-func newVarintIntIterator(reader xio.Reader) *varintIntIterator {
+func newVarintIntIterator(reader io.ByteReader) *varintIntIterator {
 	return &varintIntIterator{reader: reader}
 }
 

--- a/values/template/run_length_decode.go
+++ b/values/template/run_length_decode.go
@@ -4,8 +4,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
-
-	xio "github.com/xichen2020/eventdb/x/io"
 )
 
 var (
@@ -13,19 +11,19 @@ var (
 )
 
 // readValueFn reads a value from reader.
-type readValueFn func(reader xio.Reader) (GenericValue, error)
+type readValueFn func(reader io.ByteReader) (GenericValue, error)
 
 // runLengthDecodeValue run length decodes a stream of GenericValues.
 func runLengthDecodeValue(
 	readValueFn readValueFn,
-	reader xio.Reader,
+	reader io.ByteReader,
 ) *runLengthValueIterator {
 	return newRunLengthValueIterator(reader, readValueFn)
 }
 
 // runLengthValueIterator iterates over a run length encoded stream of values.
 type runLengthValueIterator struct {
-	reader      xio.Reader
+	reader      io.ByteReader
 	readValueFn readValueFn
 
 	curr        GenericValue
@@ -81,7 +79,7 @@ func (it *runLengthValueIterator) Close() {
 }
 
 func newRunLengthValueIterator(
-	reader xio.Reader,
+	reader io.ByteReader,
 	readValueFn readValueFn,
 ) *runLengthValueIterator {
 	return &runLengthValueIterator{


### PR DESCRIPTION
cc @black-adder @notbdu 

This PR uses the correct `io.ByteReader` type so we don't do interface conversions in tight loops.