### PR TITLE
Safely convert strings.

### DIFF
--- a/document/field/value.go
+++ b/document/field/value.go
@@ -6,7 +6,7 @@ import (
 	"math"
 
 	"github.com/xichen2020/eventdb/x/compare"
-	"github.com/xichen2020/eventdb/x/unsafe"
+	"github.com/xichen2020/eventdb/x/safe"
 
 	"github.com/cespare/xxhash"
 )
@@ -269,7 +269,7 @@ func (v *ValueUnion) Hash() uint64 {
 		// NB(xichen): Hashing on bit patterns for doubles might be problematic.
 		return 31*hash + math.Float64bits(v.DoubleVal)
 	case StringType:
-		return 31*hash + xxhash.Sum64(unsafe.ToBytes(v.StringVal))
+		return 31*hash + xxhash.Sum64(safe.ToBytes(v.StringVal))
 	case TimeType:
 		return 31*hash + uint64(v.TimeNanosVal)
 	}

--- a/parser/json/parser.go
+++ b/parser/json/parser.go
@@ -9,7 +9,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/xichen2020/eventdb/parser/json/value"
-	"github.com/xichen2020/eventdb/x/unsafe"
+	"github.com/xichen2020/eventdb/x/safe"
 )
 
 const (
@@ -130,7 +130,7 @@ func (p *parser) Parse(str string) (*value.Value, error) {
 }
 
 func (p *parser) ParseBytes(b []byte) (*value.Value, error) {
-	return p.Parse(unsafe.ToString(b))
+	return p.Parse(safe.ToString(b))
 }
 
 func (p *parser) reset() {
@@ -401,7 +401,7 @@ func (p *parser) parseStringAsRaw() (string, error) {
 		case '"':
 			p.pos += i + 1
 			escapedBytes = append(escapedBytes, data[prev:i]...)
-			return unsafe.ToString(escapedBytes), nil
+			return safe.ToString(escapedBytes), nil
 
 		case '\\':
 			escapedBytes = append(escapedBytes, data[prev:i]...)

--- a/server/http/handlers/options.go
+++ b/server/http/handlers/options.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/xichen2020/eventdb/parser/json"
 	"github.com/xichen2020/eventdb/parser/json/value"
+	"github.com/xichen2020/eventdb/x/safe"
 	"github.com/xichen2020/eventdb/x/unsafe"
 
 	"github.com/m3db/m3x/clock"
@@ -128,7 +129,7 @@ func defaultNamespaceFn(v *value.Value) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return unsafe.ToBytes(ns), nil
+	return safe.ToBytes(ns), nil
 }
 
 // defaultTimeNanosFn parses the time value as a string in RFC3339 format.

--- a/server/http/handlers/service.go
+++ b/server/http/handlers/service.go
@@ -16,7 +16,6 @@ import (
 	"github.com/xichen2020/eventdb/query"
 	"github.com/xichen2020/eventdb/storage"
 	"github.com/xichen2020/eventdb/x/safe"
-	"github.com/xichen2020/eventdb/x/unsafe"
 
 	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/context"
@@ -329,7 +328,7 @@ func (s *service) writeBatch(data []byte) error {
 
 	var multiErr xerrors.MultiError
 	for nsStr, events := range docsByNamespace {
-		nsBytes := unsafe.ToBytes(nsStr)
+		nsBytes := safe.ToBytes(nsStr)
 		if err := s.db.WriteBatch(nsBytes, events); err != nil {
 			multiErr = multiErr.Add(err)
 		}

--- a/server/http/handlers/service.go
+++ b/server/http/handlers/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/xichen2020/eventdb/parser/json/value"
 	"github.com/xichen2020/eventdb/query"
 	"github.com/xichen2020/eventdb/storage"
+	"github.com/xichen2020/eventdb/x/safe"
 	"github.com/xichen2020/eventdb/x/unsafe"
 
 	"github.com/m3db/m3x/clock"
@@ -318,7 +319,7 @@ func (s *service) writeBatch(data []byte) error {
 		if err != nil {
 			return fmt.Errorf("cannot parse document from %s: %v", docBytes, err)
 		}
-		nsStr := unsafe.ToString(ns)
+		nsStr := safe.ToString(ns)
 		docsByNamespace[nsStr] = append(docsByNamespace[nsStr], doc)
 		start = end + 1
 		batchSize++

--- a/storage/database.go
+++ b/storage/database.go
@@ -9,7 +9,7 @@ import (
 	"github.com/xichen2020/eventdb/query"
 	"github.com/xichen2020/eventdb/sharding"
 	"github.com/xichen2020/eventdb/x/hash"
-	"github.com/xichen2020/eventdb/x/unsafe"
+	"github.com/xichen2020/eventdb/x/safe"
 
 	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/context"
@@ -202,7 +202,7 @@ func (d *db) QueryRaw(
 	q query.ParsedRawQuery,
 ) (*query.RawResults, error) {
 	callStart := d.nowFn()
-	n, err := d.namespaceFor(unsafe.ToBytes(q.Namespace))
+	n, err := d.namespaceFor(safe.ToBytes(q.Namespace))
 	if err != nil {
 		d.metrics.queryRaw.ReportError(d.nowFn().Sub(callStart))
 		return nil, err
@@ -217,7 +217,7 @@ func (d *db) QueryGrouped(
 	q query.ParsedGroupedQuery,
 ) (*query.GroupedResults, error) {
 	callStart := d.nowFn()
-	n, err := d.namespaceFor(unsafe.ToBytes(q.Namespace))
+	n, err := d.namespaceFor(safe.ToBytes(q.Namespace))
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (d *db) QueryTimeBucket(
 	q query.ParsedTimeBucketQuery,
 ) (*query.TimeBucketResults, error) {
 	callStart := d.nowFn()
-	n, err := d.namespaceFor(unsafe.ToBytes(q.Namespace))
+	n, err := d.namespaceFor(safe.ToBytes(q.Namespace))
 	if err != nil {
 		return nil, err
 	}

--- a/storage/mutable_segment.go
+++ b/storage/mutable_segment.go
@@ -11,8 +11,8 @@ import (
 	"github.com/xichen2020/eventdb/persist"
 	"github.com/xichen2020/eventdb/query"
 	"github.com/xichen2020/eventdb/x/hash"
+	"github.com/xichen2020/eventdb/x/safe"
 	"github.com/xichen2020/eventdb/x/strings"
-	"github.com/xichen2020/eventdb/x/unsafe"
 
 	"github.com/m3db/m3x/context"
 )
@@ -572,7 +572,7 @@ func (s *mutableSeg) writeTimestampFieldWithLock(docID int32, val int64) {
 func (s *mutableSeg) writeRawDocSourceFieldWithLock(docID int32, val []byte) {
 	v := field.ValueUnion{
 		Type:      field.StringType,
-		StringVal: unsafe.ToString(val),
+		StringVal: safe.ToString(val),
 	}
 	s.rawDocSourceField.Add(docID, v)
 }

--- a/x/safe/convert.go
+++ b/x/safe/convert.go
@@ -1,0 +1,8 @@
+package safe
+
+// ToString safely converts a byte slice to a string.
+// TODO: This method should be removed when we move over to handling bytes in the
+// database hot path instead of strings.
+func ToString(b []byte) string {
+	return string(b)
+}

--- a/x/safe/convert.go
+++ b/x/safe/convert.go
@@ -6,3 +6,10 @@ package safe
 func ToString(b []byte) string {
 	return string(b)
 }
+
+// ToBytes safely converts a string to a byte slice.
+// TODO: This method should be removed when we move over to handling bytes in the
+// database hot path instead of strings.
+func ToBytes(s string) []byte {
+	return []byte(s)
+}


### PR DESCRIPTION
Fixes #134. 

Safely convert strings so we can get on w/ gathering perf data on queries etc.